### PR TITLE
feature: client list command support --all-namespaces options, issue #66

### DIFF
--- a/bcs-services/bcs-client/cmd/list/agent.go
+++ b/bcs-services/bcs-client/cmd/list/agent.go
@@ -29,7 +29,7 @@ func listAgent(c *utils.ClientContext) error {
 	}
 
 	condition := url.Values{}
-	condition.Add("namespace", c.Namespace())
+	condition.Add(FilterNamespaceTag, c.Namespace())
 
 	ipList := utils.GetIPList(c.String(utils.OptionIP))
 

--- a/bcs-services/bcs-client/cmd/list/application.go
+++ b/bcs-services/bcs-client/cmd/list/application.go
@@ -16,6 +16,7 @@ package list
 import (
 	"fmt"
 	"net/url"
+	"sort"
 
 	commonTypes "bk-bcs/bcs-common/common/types"
 	"bk-bcs/bcs-services/bcs-client/cmd/utils"
@@ -27,15 +28,25 @@ func listApplication(c *utils.ClientContext) error {
 		return err
 	}
 
-	condition := url.Values{}
-	condition.Add("namespace", c.Namespace())
-
 	storage := v1.NewBcsStorage(utils.GetClientOption())
+
+	// get namespace
+	condition := url.Values{}
+	condition.Add(FilterNamespaceTag, c.Namespace())
+
+	if c.IsAllNamespace() {
+		var err error
+		if condition, err = getNamespaceFilter(storage, c.ClusterID()); err != nil {
+			return err
+		}
+	}
+
 	list, err := storage.ListApplication(c.ClusterID(), condition)
 	if err != nil {
 		return fmt.Errorf("failed to list application: %v", err)
 	}
 
+	sort.Sort(list)
 	return printListApplication(list)
 }
 

--- a/bcs-services/bcs-client/cmd/list/configmap.go
+++ b/bcs-services/bcs-client/cmd/list/configmap.go
@@ -16,6 +16,7 @@ package list
 import (
 	"fmt"
 	"net/url"
+	"sort"
 
 	"bk-bcs/bcs-services/bcs-client/cmd/utils"
 	"bk-bcs/bcs-services/bcs-client/pkg/storage/v1"
@@ -26,15 +27,25 @@ func listConfigMap(c *utils.ClientContext) error {
 		return err
 	}
 
-	condition := url.Values{}
-	condition.Add("namespace", c.Namespace())
-
 	storage := v1.NewBcsStorage(utils.GetClientOption())
+
+	// get namespace
+	condition := url.Values{}
+	condition.Add(FilterNamespaceTag, c.Namespace())
+
+	if c.IsAllNamespace() {
+		var err error
+		if condition, err = getNamespaceFilter(storage, c.ClusterID()); err != nil {
+			return err
+		}
+	}
+
 	list, err := storage.ListConfigMap(c.ClusterID(), condition)
 	if err != nil {
 		return fmt.Errorf("failed to list configmap: %v", err)
 	}
 
+	sort.Sort(list)
 	return printListConfigMap(list)
 }
 

--- a/bcs-services/bcs-client/cmd/list/deployment.go
+++ b/bcs-services/bcs-client/cmd/list/deployment.go
@@ -16,6 +16,7 @@ package list
 import (
 	"fmt"
 	"net/url"
+	"sort"
 
 	"bk-bcs/bcs-services/bcs-client/cmd/utils"
 	"bk-bcs/bcs-services/bcs-client/pkg/storage/v1"
@@ -26,15 +27,25 @@ func listDeployment(c *utils.ClientContext) error {
 		return err
 	}
 
-	condition := url.Values{}
-	condition.Add("namespace", c.Namespace())
-
 	storage := v1.NewBcsStorage(utils.GetClientOption())
+
+	// get namespace
+	condition := url.Values{}
+	condition.Add(FilterNamespaceTag, c.Namespace())
+
+	if c.IsAllNamespace() {
+		var err error
+		if condition, err = getNamespaceFilter(storage, c.ClusterID()); err != nil {
+			return err
+		}
+	}
+
 	list, err := storage.ListDeployment(c.ClusterID(), condition)
 	if err != nil {
 		return fmt.Errorf("failed to list deployment: %v", err)
 	}
 
+	sort.Sort(list)
 	return printListDeployment(list)
 }
 

--- a/bcs-services/bcs-client/cmd/list/endpoint.go
+++ b/bcs-services/bcs-client/cmd/list/endpoint.go
@@ -16,6 +16,7 @@ package list
 import (
 	"fmt"
 	"net/url"
+	"sort"
 
 	"bk-bcs/bcs-services/bcs-client/cmd/utils"
 	"bk-bcs/bcs-services/bcs-client/pkg/storage/v1"
@@ -26,15 +27,25 @@ func listEndpoint(c *utils.ClientContext) error {
 		return err
 	}
 
-	condition := url.Values{}
-	condition.Add("namespace", c.Namespace())
-
 	storage := v1.NewBcsStorage(utils.GetClientOption())
+
+	// get namespace
+	condition := url.Values{}
+	condition.Add(FilterNamespaceTag, c.Namespace())
+
+	if c.IsAllNamespace() {
+		var err error
+		if condition, err = getNamespaceFilter(storage, c.ClusterID()); err != nil {
+			return err
+		}
+	}
+
 	list, err := storage.ListEndpoint(c.ClusterID(), condition)
 	if err != nil {
 		return fmt.Errorf("failed to list endpoint: %v", err)
 	}
 
+	sort.Sort(list)
 	return printListEndpoint(list)
 }
 

--- a/bcs-services/bcs-client/cmd/list/list.go
+++ b/bcs-services/bcs-client/cmd/list/list.go
@@ -39,6 +39,10 @@ func NewListCommand() cli.Command {
 				Usage: "Namespace",
 				Value: "",
 			},
+			cli.BoolFlag{
+				Name: "all-namespaces, an",
+				Usage: "list resources with all namespaces",
+			},
 			cli.StringFlag{
 				Name:  "ip",
 				Usage: "The ip of taskgroup. Split by ,",
@@ -85,3 +89,7 @@ func list(c *utils.ClientContext) error {
 		return fmt.Errorf("invalid type: %s", resourceType)
 	}
 }
+
+const (
+	FilterNamespaceTag = "namespace"
+)

--- a/bcs-services/bcs-client/cmd/list/namespace.go
+++ b/bcs-services/bcs-client/cmd/list/namespace.go
@@ -17,6 +17,7 @@ import (
 	"bk-bcs/bcs-services/bcs-client/cmd/utils"
 	"bk-bcs/bcs-services/bcs-client/pkg/storage/v1"
 	"fmt"
+	"net/url"
 )
 
 func listNamespace(c *utils.ClientContext) error {
@@ -44,4 +45,18 @@ func printListNamespace(list []string) error {
 		fmt.Printf("%-5d %-20s\n", i, ns)
 	}
 	return nil
+}
+
+func getNamespaceFilter(storage v1.Storage, clusterID string) (url.Values, error) {
+	ns, err := storage.ListNamespace(clusterID, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list all namespace: %v", err)
+	}
+
+	data := url.Values{}
+	for _, item := range ns {
+		data.Add(FilterNamespaceTag, item)
+	}
+
+	return data, nil
 }

--- a/bcs-services/bcs-client/cmd/list/process.go
+++ b/bcs-services/bcs-client/cmd/list/process.go
@@ -16,6 +16,7 @@ package list
 import (
 	"fmt"
 	"net/url"
+	"sort"
 
 	commonTypes "bk-bcs/bcs-common/common/types"
 	"bk-bcs/bcs-services/bcs-client/cmd/utils"
@@ -27,15 +28,25 @@ func listProcess(c *utils.ClientContext) error {
 		return err
 	}
 
-	condition := url.Values{}
-	condition.Add("namespace", c.Namespace())
-
 	storage := v1.NewBcsStorage(utils.GetClientOption())
+
+	// get namespace
+	condition := url.Values{}
+	condition.Add(FilterNamespaceTag, c.Namespace())
+
+	if c.IsAllNamespace() {
+		var err error
+		if condition, err = getNamespaceFilter(storage, c.ClusterID()); err != nil {
+			return err
+		}
+	}
+
 	list, err := storage.ListProcess(c.ClusterID(), condition)
 	if err != nil {
 		return fmt.Errorf("failed to list process: %v", err)
 	}
 
+	sort.Sort(list)
 	return printListProcess(list)
 }
 

--- a/bcs-services/bcs-client/cmd/list/secret.go
+++ b/bcs-services/bcs-client/cmd/list/secret.go
@@ -16,6 +16,7 @@ package list
 import (
 	"fmt"
 	"net/url"
+	"sort"
 
 	"bk-bcs/bcs-services/bcs-client/cmd/utils"
 	"bk-bcs/bcs-services/bcs-client/pkg/storage/v1"
@@ -26,15 +27,25 @@ func listSecret(c *utils.ClientContext) error {
 		return err
 	}
 
-	condition := url.Values{}
-	condition.Add("namespace", c.Namespace())
-
 	storage := v1.NewBcsStorage(utils.GetClientOption())
+
+	// get namespace
+	condition := url.Values{}
+	condition.Add(FilterNamespaceTag, c.Namespace())
+
+	if c.IsAllNamespace() {
+		var err error
+		if condition, err = getNamespaceFilter(storage, c.ClusterID()); err != nil {
+			return err
+		}
+	}
+
 	list, err := storage.ListSecret(c.ClusterID(), condition)
 	if err != nil {
 		return fmt.Errorf("failed to list secret: %v", err)
 	}
 
+	sort.Sort(list)
 	return printListSecret(list)
 }
 

--- a/bcs-services/bcs-client/cmd/list/service.go
+++ b/bcs-services/bcs-client/cmd/list/service.go
@@ -16,6 +16,7 @@ package list
 import (
 	"fmt"
 	"net/url"
+	"sort"
 
 	"bk-bcs/bcs-services/bcs-client/cmd/utils"
 	"bk-bcs/bcs-services/bcs-client/pkg/storage/v1"
@@ -26,15 +27,25 @@ func listService(c *utils.ClientContext) error {
 		return err
 	}
 
-	condition := url.Values{}
-	condition.Add("namespace", c.Namespace())
-
 	storage := v1.NewBcsStorage(utils.GetClientOption())
+
+	// get namespace
+	condition := url.Values{}
+	condition.Add(FilterNamespaceTag, c.Namespace())
+
+	if c.IsAllNamespace() {
+		var err error
+		if condition, err = getNamespaceFilter(storage, c.ClusterID()); err != nil {
+			return err
+		}
+	}
+
 	list, err := storage.ListService(c.ClusterID(), condition)
 	if err != nil {
 		return fmt.Errorf("failed to list service: %v", err)
 	}
 
+	sort.Sort(list)
 	return printListService(list)
 }
 

--- a/bcs-services/bcs-client/cmd/utils/types.go
+++ b/bcs-services/bcs-client/cmd/utils/types.go
@@ -16,6 +16,7 @@ package utils
 const (
 	OptionClusterID     = "clusterid"
 	OptionNamespace     = "namespace"
+	OptionAllNamespace  = "all-namespaces"
 	OptionName          = "name"
 	OptionTaskGroupName = "tgname"
 	OptionType          = "type"

--- a/bcs-services/bcs-client/cmd/utils/utils.go
+++ b/bcs-services/bcs-client/cmd/utils/utils.go
@@ -166,8 +166,9 @@ func DebugPrintf(format string, a ...interface{}) {
 type ClientContext struct {
 	*cli.Context
 
-	clusterID string
-	namespace string
+	clusterID    string
+	namespace    string
+	allNamespace bool
 }
 
 func NewClientContext(c *cli.Context) *ClientContext {
@@ -185,7 +186,7 @@ func (cc *ClientContext) MustSpecified(key ...string) error {
 			continue
 		}
 		if k == OptionNamespace {
-			if cc.namespace == "" {
+			if cc.namespace == "" && !cc.allNamespace {
 				return fmt.Errorf("namespace must be specified, options or env")
 			}
 			continue
@@ -209,6 +210,10 @@ func (cc *ClientContext) initEnv() {
 	if cc.IsSet(OptionNamespace) && cc.String(OptionNamespace) != "" {
 		cc.namespace = cc.String(OptionNamespace)
 	}
+
+	if cc.IsSet(OptionAllNamespace) {
+		cc.allNamespace = cc.Bool(OptionAllNamespace)
+	}
 }
 
 func (cc *ClientContext) ClusterID() string {
@@ -217,6 +222,10 @@ func (cc *ClientContext) ClusterID() string {
 
 func (cc *ClientContext) Namespace() string {
 	return cc.namespace
+}
+
+func (cc *ClientContext) IsAllNamespace() bool {
+	return cc.allNamespace
 }
 
 func (cc *ClientContext) FileData() ([]byte, error) {

--- a/bcs-services/bcs-client/pkg/storage/v1/types.go
+++ b/bcs-services/bcs-client/pkg/storage/v1/types.go
@@ -70,3 +70,29 @@ type SecretList []*SecretSet
 type ServiceList []*ServiceSet
 type EndpointList []*EndpointSet
 type DeploymentList []*DeploymentSet
+
+// sort by namespace
+func (l ApplicationList) Len() int           { return len(l) }
+func (l ApplicationList) Less(i, j int) bool { return l[i].Data.NameSpace > l[j].Data.NameSpace }
+func (l ApplicationList) Swap(i, j int)      { l[i], l[j] = l[j], l[i] }
+func (l ProcessList)     Len() int           { return len(l) }
+func (l ProcessList)     Less(i, j int) bool { return l[i].Data.NameSpace > l[j].Data.NameSpace }
+func (l ProcessList)     Swap(i, j int)      { l[i], l[j] = l[j], l[i] }
+func (l TaskGroupList)   Len() int           { return len(l) }
+func (l TaskGroupList)   Less(i, j int) bool { return l[i].Data.NameSpace > l[j].Data.NameSpace }
+func (l TaskGroupList)   Swap(i, j int)      { l[i], l[j] = l[j], l[i] }
+func (l ConfigMapList)   Len() int           { return len(l) }
+func (l ConfigMapList)   Less(i, j int) bool { return l[i].Data.NameSpace > l[j].Data.NameSpace }
+func (l ConfigMapList)   Swap(i, j int)      { l[i], l[j] = l[j], l[i] }
+func (l SecretList)      Len() int           { return len(l) }
+func (l SecretList)      Less(i, j int) bool { return l[i].Data.NameSpace > l[j].Data.NameSpace }
+func (l SecretList)      Swap(i, j int)      { l[i], l[j] = l[j], l[i] }
+func (l ServiceList)     Len() int           { return len(l) }
+func (l ServiceList)     Less(i, j int) bool { return l[i].Data.NameSpace > l[j].Data.NameSpace }
+func (l ServiceList)     Swap(i, j int)      { l[i], l[j] = l[j], l[i] }
+func (l EndpointList)    Len() int           { return len(l) }
+func (l EndpointList)    Less(i, j int) bool { return l[i].Data.NameSpace > l[j].Data.NameSpace }
+func (l EndpointList)    Swap(i, j int)      { l[i], l[j] = l[j], l[i] }
+func (l DeploymentList)  Len() int           { return len(l) }
+func (l DeploymentList)  Less(i, j int) bool { return l[i].Data.ObjectMeta.NameSpace > l[j].Data.ObjectMeta.NameSpace }
+func (l DeploymentList)  Swap(i, j int)      { l[i], l[j] = l[j], l[i] }


### PR DESCRIPTION
feature:
- client list command support --all-namespaces options

```
OPTIONS:
--all-namespaces, --an         list resources with all namespaces

USAGE:
bcs-client list -t app --all-namespaces
```