### PR TITLE
feature: bcs-k8s-watch support k8s 1.16+ version, bcs-api compatible …

### DIFF
--- a/bcs-k8s/bcs-k8s-driver/kubedriver/versions/metaurls.go
+++ b/bcs-k8s/bcs-k8s-driver/kubedriver/versions/metaurls.go
@@ -26,6 +26,12 @@ var apiVersionMap = map[string][]string{
 	"1.13+": apiSetV112,
 	"1.14":  apiSetV112,
 	"1.14+": apiSetV112,
+	"1.15":  apiSetV112,
+	"1.16":  apiSetV112,
+	"1.17":  apiSetV112,
+	"1.18":  apiSetV112,
+	"1.19":  apiSetV112,
+	"1.20":  apiSetV112,
 }
 
 var apiSetV15 = []string{

--- a/bcs-services/bcs-api/pkg/component/auth.go
+++ b/bcs-services/bcs-api/pkg/component/auth.go
@@ -57,7 +57,7 @@ func (a *PaaSAuth) VerifyAccessTokenForIeod(accessToken string) (bool, map[strin
 
 func (a *PaaSAuth) VerifyAccessTokenForEe(accessToken string) (bool, map[string]interface{}, error) {
 
-	url := fmt.Sprintf("%s/bkiam/api/v1/auth/access-tokens/verify", a.host)
+	url := fmt.Sprintf("%s/api/v1/auth/access-tokens/verify", a.host)
 
 	data := map[string]interface{}{
 		"access_token": accessToken,


### PR DESCRIPTION
…with new version bk-auth. issue #567