### PR TITLE
fix: gamestatefulset rollingUpdate.Partition panic && gamestatefulset monotonic control for updated version replica, not all replica

### DIFF
--- a/bcs-k8s/bcs-gamestatefulset-operator/pkg/controllers/game_stateful_set_control.go
+++ b/bcs-k8s/bcs-gamestatefulset-operator/pkg/controllers/game_stateful_set_control.go
@@ -589,7 +589,7 @@ func (ssc *defaultGameStatefulSetControl) updateGameStatefulSet(
 		// If we have a Pod that has been created but is not running and ready we can not make progress.
 		// We must ensure that all for each Pod, when we create it, all of its predecessors, with respect to its
 		// ordinal, are Running and Ready.
-		if !isRunningAndReady(replicas[i]) && monotonic {
+		if monotonic && (getPodRevision(replicas[i]) == updateRevision.Name) && (!isRunningAndReady(replicas[i]))  {
 			klog.V(3).Infof(
 				"GameStatefulSet %s/%s is waiting for Pod %s to be Running and Ready",
 				set.Namespace,

--- a/bcs-k8s/bcs-gamestatefulset-operator/pkg/util/canary/canary.go
+++ b/bcs-k8s/bcs-gamestatefulset-operator/pkg/util/canary/canary.go
@@ -47,7 +47,7 @@ func GetCurrentPartition(set *gstsv1alpha1.GameStatefulSet) int32 {
 	currentStep, currentStepIndex := GetCurrentCanaryStep(set)
 	if currentStep == nil {
 		if (set.Spec.UpdateStrategy.CanaryStrategy == nil || len(set.Spec.UpdateStrategy.CanaryStrategy.Steps) == 0) &&
-			set.Spec.UpdateStrategy.RollingUpdate.Partition != nil {
+			set.Spec.UpdateStrategy.RollingUpdate != nil && set.Spec.UpdateStrategy.RollingUpdate.Partition != nil {
 			return *set.Spec.UpdateStrategy.RollingUpdate.Partition
 		}
 		return 0


### PR DESCRIPTION
monotonic control test case:
## 测试imageID不变的更新后，卡住，然后再更新能顺利通过。
```shell
[root@kvm-02 ~]# kubectl get po -n wessonli-test -o wide -w
NAME                     READY   STATUS    RESTARTS   AGE     IP           NODE     NOMINATED NODE   READINESS GATES
test-gamestatefulset-2   1/1     Running   1          4m59s   10.42.0.91   kvm-02   <none>           1/1
test-gamestatefulset-1   1/1     Running   1          6m11s   10.42.0.90   kvm-02   <none>           1/1
test-gamestatefulset-0   1/1     Running   1          7m23s   10.42.0.89   kvm-02   <none>           1/1

### 更新为相同imageID的镜像，ReadinessGate是false，更新会卡在这里
test-gamestatefulset-2   1/1     Running   1          8m37s   10.42.0.91   kvm-02   <none>           0/1
test-gamestatefulset-2   1/1     Running   1          8m37s   10.42.0.91   kvm-02   <none>           0/1
test-gamestatefulset-2   1/1     Running   1          8m37s   10.42.0.91   kvm-02   <none>           0/1
test-gamestatefulset-2   1/1     Running   1          9m7s    10.42.0.91   kvm-02   <none>           0/1
test-gamestatefulset-2   1/1     Running   2          9m8s    10.42.0.91   kvm-02   <none>           0/1
test-gamestatefulset-2   1/1     Running   2          12m     10.42.0.91   kvm-02   <none>           0/1
test-gamestatefulset-2   1/1     Running   2          12m     10.42.0.91   kvm-02   <none>           0/1
test-gamestatefulset-2   1/1     Running   2          12m     10.42.0.91   kvm-02   <none>           0/1
test-gamestatefulset-2   1/1     Running   2          13m     10.42.0.91   kvm-02   <none>           0/1

### 再次提交一版imageID不同的镜像，不会卡住，将触发新一轮的更新，符合预期
test-gamestatefulset-2   1/1     Running   3          13m     10.42.0.91   kvm-02   <none>           0/1
test-gamestatefulset-2   1/1     Running   3          13m     10.42.0.91   kvm-02   <none>           1/1
test-gamestatefulset-2   1/1     Running   3          13m     10.42.0.91   kvm-02   <none>           1/1
test-gamestatefulset-2   1/1     Running   3          13m     10.42.0.91   kvm-02   <none>           1/1
test-gamestatefulset-1   1/1     Running   1          13m     10.42.0.90   kvm-02   <none>           0/1
test-gamestatefulset-1   1/1     Running   1          13m     10.42.0.90   kvm-02   <none>           0/1
test-gamestatefulset-1   1/1     Running   1          13m     10.42.0.90   kvm-02   <none>           0/1
test-gamestatefulset-1   1/1     Running   1          14m     10.42.0.90   kvm-02   <none>           0/1
test-gamestatefulset-1   1/1     Running   2          14m     10.42.0.90   kvm-02   <none>           0/1
test-gamestatefulset-1   1/1     Running   2          14m     10.42.0.90   kvm-02   <none>           1/1
test-gamestatefulset-1   1/1     Running   2          14m     10.42.0.90   kvm-02   <none>           1/1
test-gamestatefulset-1   1/1     Running   2          14m     10.42.0.90   kvm-02   <none>           1/1
test-gamestatefulset-0   1/1     Running   1          15m     10.42.0.89   kvm-02   <none>           0/1
test-gamestatefulset-0   1/1     Running   1          15m     10.42.0.89   kvm-02   <none>           0/1
test-gamestatefulset-0   1/1     Running   1          15m     10.42.0.89   kvm-02   <none>           0/1
test-gamestatefulset-0   1/1     Running   1          15m     10.42.0.89   kvm-02   <none>           0/1
test-gamestatefulset-0   1/1     Running   2          15m     10.42.0.89   kvm-02   <none>           0/1
test-gamestatefulset-0   1/1     Running   2          15m     10.42.0.89   kvm-02   <none>           1/1
test-gamestatefulset-0   1/1     Running   2          15m     10.42.0.89   kvm-02   <none>           1/1
test-gamestatefulset-0   1/1     Running   2          15m     10.42.0.89   kvm-02   <none>           1/1


## 测试：如果新版本的container not ready，将不会继续往下更新，发fix的新版本后，又能继续（hook校验规则要注意 能保证异常Pod也允许更新）
test-gamestatefulset-0   1/1     Running            3          47m   10.42.0.89   kvm-02   <none>           1/1
test-gamestatefulset-2   1/1     Running            4          50m   10.42.0.91   kvm-02   <none>           0/1
test-gamestatefulset-2   1/1     Running            4          50m   10.42.0.91   kvm-02   <none>           0/1
test-gamestatefulset-2   1/1     Running            4          50m   10.42.0.91   kvm-02   <none>           0/1
test-gamestatefulset-2   1/1     Running            4          50m   10.42.0.91   kvm-02   <none>           0/1
test-gamestatefulset-2   0/1     ErrImagePull       4          51m   10.42.0.91   kvm-02   <none>           0/1
test-gamestatefulset-2   0/1     CrashLoopBackOff   4          51m   10.42.0.91   kvm-02   <none>           0/1
test-gamestatefulset-2   0/1     ErrImagePull       4          51m   10.42.0.91   kvm-02   <none>           0/1
test-gamestatefulset-2   0/1     ImagePullBackOff   4          51m   10.42.0.91   kvm-02   <none>           0/1
test-gamestatefulset-2   0/1     ErrImagePull       4          52m   10.42.0.91   kvm-02   <none>           0/1
test-gamestatefulset-2   0/1     CrashLoopBackOff   4          52m   10.42.0.91   kvm-02   <none>           0/1
test-gamestatefulset-2   0/1     ImagePullBackOff   4          52m   10.42.0.91   kvm-02   <none>           0/1
test-gamestatefulset-2   0/1     CrashLoopBackOff   4          52m   10.42.0.91   kvm-02   <none>           0/1
test-gamestatefulset-2   0/1     ErrImagePull       4          53m   10.42.0.91   kvm-02   <none>           0/1
test-gamestatefulset-2   0/1     ErrImagePull       4          54m   10.42.0.91   kvm-02   <none>           0/1
test-gamestatefulset-2   0/1     ErrImagePull       4          54m   10.42.0.91   kvm-02   <none>           0/1
test-gamestatefulset-2   0/1     CrashLoopBackOff   4          54m   10.42.0.91   kvm-02   <none>           0/1
test-gamestatefulset-2   0/1     CrashLoopBackOff   4          54m   10.42.0.91   kvm-02   <none>           0/1
test-gamestatefulset-2   1/1     Running            5          54m   10.42.0.91   kvm-02   <none>           0/1
test-gamestatefulset-2   1/1     Running            5          54m   10.42.0.91   kvm-02   <none>           1/1
test-gamestatefulset-2   1/1     Running            5          54m   10.42.0.91   kvm-02   <none>           1/1
test-gamestatefulset-2   1/1     Running            5          54m   10.42.0.91   kvm-02   <none>           1/1
test-gamestatefulset-1   1/1     Running            3          55m   10.42.0.90   kvm-02   <none>           0/1
test-gamestatefulset-1   1/1     Running            3          55m   10.42.0.90   kvm-02   <none>           0/1
test-gamestatefulset-1   1/1     Running            3          55m   10.42.0.90   kvm-02   <none>           0/1
test-gamestatefulset-1   1/1     Running            3          55m   10.42.0.90   kvm-02   <none>           0/1
test-gamestatefulset-1   1/1     Running            4          55m   10.42.0.90   kvm-02   <none>           0/1
test-gamestatefulset-1   1/1     Running            4          55m   10.42.0.90   kvm-02   <none>           1/1
test-gamestatefulset-1   1/1     Running            4          55m   10.42.0.90   kvm-02   <none>           1/1
test-gamestatefulset-1   1/1     Running            4          55m   10.42.0.90   kvm-02   <none>           1/1
test-gamestatefulset-0   1/1     Running            3          56m   10.42.0.89   kvm-02   <none>           0/1
test-gamestatefulset-0   1/1     Running            3          56m   10.42.0.89   kvm-02   <none>           0/1
test-gamestatefulset-0   1/1     Running            3          56m   10.42.0.89   kvm-02   <none>           0/1
test-gamestatefulset-0   1/1     Running            3          56m   10.42.0.89   kvm-02   <none>           0/1
test-gamestatefulset-0   1/1     Running            4          56m   10.42.0.89   kvm-02   <none>           0/1
test-gamestatefulset-0   1/1     Running            4          56m   10.42.0.89   kvm-02   <none>           1/1
test-gamestatefulset-0   1/1     Running            4          57m   10.42.0.89   kvm-02   <none>           1/1
test-gamestatefulset-0   1/1     Running            4          57m   10.42.0.89   kvm-02   <none>           1/1
```