### PR TITLE
bcslogconfigs 定义添加PodNamePattern字段，以支持logbeat-sidecar的静态pod日志采集需求

### DIFF
--- a/bcs-k8s/kubebkbcs/apis/bkbcs/v1/bcslogconfig_types.go
+++ b/bcs-k8s/kubebkbcs/apis/bkbcs/v1/bcslogconfig_types.go
@@ -47,6 +47,7 @@ type BcsLogConfigSpec struct {
 	WorkloadNamespace string            `json:"workloadNamespace"`
 	ContainerConfs    []ContainerConf   `json:"containerConfs"`
 	PodLabels         bool              `json:"podLabels"`
+	PodNamePattern    string            `json:"podNamePattern"`
 	Selector          PodSelector       `json:"selector"`
 	PackageCollection bool              `json:"packageCollection"`
 }


### PR DESCRIPTION
issue #890