### PR TITLE
更新各模块所依赖 bcs-common 版本，支持社区无硬编译密码部署

### DIFF
--- a/bcs-k8s/bcs-k8s-custom-scheduler/go.mod
+++ b/bcs-k8s/bcs-k8s-custom-scheduler/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 replace (
 	bitbucket.org/ww/goautoneg => github.com/adjust/goautoneg v0.0.0-20150426214442-d788f35a0315
-	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210201154723-6cbc7cfcb38d
+	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210818040851-76fdc539dc33
 	github.com/Tencent/bk-bcs/bcs-k8s/kubedeprecated => github.com/Tencent/bk-bcs/bcs-k8s/kubedeprecated v0.0.0-20210117140338-aeaed29b1997
 	github.com/Tencent/bk-bcs/bcs-k8s/kubernetes => github.com/Tencent/bk-bcs/bcs-k8s/kubernetes v0.0.0-20210608083141-16270a254fb4
 	github.com/Tencent/bk-bcs/bcs-network => ../../bcs-network

--- a/bcs-k8s/bcs-k8s-driver/go.mod
+++ b/bcs-k8s/bcs-k8s-driver/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 replace (
 	bitbucket.org/ww/goautoneg => github.com/adjust/goautoneg v0.0.0-20150426214442-d788f35a0315
-	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210117140338-aeaed29b1997
+	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210818040851-76fdc539dc33
 	github.com/Tencent/bk-bcs/bcs-k8s/bcs-gamedeployment-operator => ../../bcs-k8s/bcs-gamedeployment-operator
 	github.com/Tencent/bk-bcs/bcs-k8s/bcs-gamestatefulset-operator => ../../bcs-k8s/bcs-gamestatefulset-operator
 	github.com/Tencent/bk-bcs/bcs-k8s/bcs-k8s-watch => ../../bcs-k8s/bcs-k8s-watch

--- a/bcs-k8s/bcs-k8s-watch/go.mod
+++ b/bcs-k8s/bcs-k8s-watch/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 replace (
 	bitbucket.org/ww/goautoneg => github.com/adjust/goautoneg v0.0.0-20150426214442-d788f35a0315
-	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210117140338-aeaed29b1997
+	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210818040851-76fdc539dc33
 	github.com/Tencent/bk-bcs/bcs-k8s/bcs-gamedeployment-operator => ../../bcs-k8s/bcs-gamedeployment-operator
 	github.com/Tencent/bk-bcs/bcs-k8s/bcs-gamestatefulset-operator => ../../bcs-k8s/bcs-gamestatefulset-operator
 	github.com/Tencent/bk-bcs/bcs-k8s/kubebkbcs => github.com/Tencent/bk-bcs/bcs-k8s/kubebkbcs v0.0.0-20210117140338-aeaed29b1997

--- a/bcs-k8s/bcs-kube-agent/go.mod
+++ b/bcs-k8s/bcs-kube-agent/go.mod
@@ -3,8 +3,8 @@ module github.com/Tencent/bk-bcs/bcs-k8s/bcs-kube-agent
 go 1.14
 
 replace (
-	//github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210204122842-0a7ba2fb84ff
-	github.com/Tencent/bk-bcs/bcs-common => ../../bcs-common
+	//github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210818040851-76fdc539dc33
+	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210818040851-76fdc539dc33
 	github.com/coreos/bbolt v1.3.4 => go.etcd.io/bbolt v1.3.4
 	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.0
 	go.etcd.io/bbolt v1.3.4 => github.com/coreos/bbolt v1.3.4

--- a/bcs-mesos/bcs-scheduler/go.mod
+++ b/bcs-mesos/bcs-scheduler/go.mod
@@ -3,7 +3,7 @@ module github.com/Tencent/bk-bcs/bcs-mesos/bcs-scheduler
 go 1.14
 
 replace (
-	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210625040556-0385f88cbfd6
+	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210818040851-76fdc539dc33
 	github.com/Tencent/bk-bcs/bcs-mesos/kubebkbcsv2 => ../kubebkbcsv2
 	github.com/coreos/bbolt v1.3.4 => go.etcd.io/bbolt v1.3.4
 	go.etcd.io/bbolt v1.3.4 => github.com/coreos/bbolt v1.3.4

--- a/bcs-mesos/kubebkbcsv2/go.mod
+++ b/bcs-mesos/kubebkbcsv2/go.mod
@@ -3,7 +3,7 @@ module github.com/Tencent/bk-bcs/bcs-mesos/kubebkbcsv2
 go 1.14
 
 replace (
-	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210517123645-82ef0026bf95
+	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210818040851-76fdc539dc33
 	github.com/coreos/bbolt v1.3.4 => go.etcd.io/bbolt v1.3.4
 	go.etcd.io/bbolt v1.3.4 => github.com/coreos/bbolt v1.3.4
 )

--- a/bcs-network/go.mod
+++ b/bcs-network/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 replace (
 	bitbucket.org/ww/goautoneg => github.com/adjust/goautoneg v0.0.0-20150426214442-d788f35a0315
-	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210517123645-82ef0026bf95
+	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210818040851-76fdc539dc33
 	github.com/Tencent/bk-bcs/bcs-k8s/kubedeprecated => github.com/Tencent/bk-bcs/bcs-k8s/kubedeprecated v0.0.0-20210117140338-aeaed29b1997
 	github.com/Tencent/bk-bcs/bcs-k8s/kubernetes => github.com/Tencent/bk-bcs/bcs-k8s/kubernetes v0.0.0-20210608083141-16270a254fb4
 	github.com/containernetworking/cni => github.com/containernetworking/cni v0.6.0
@@ -23,13 +23,13 @@ require (
 	github.com/Tencent/bk-bcs/bcs-common v0.0.0-00010101000000-000000000000
 	github.com/Tencent/bk-bcs/bcs-k8s/kubedeprecated v0.0.0-00010101000000-000000000000
 	github.com/Tencent/bk-bcs/bcs-k8s/kubernetes v0.0.0-00010101000000-000000000000
-	github.com/Tencent/bk-bcs/bcs-mesos/mesosv2 v0.0.0-20210117140338-aeaed29b1997 // indirect
+	github.com/Tencent/bk-bcs/bcs-mesos/mesosv2 v0.0.0-20210117140338-aeaed29b1997
 	github.com/aws/aws-sdk-go v1.34.28
 	github.com/containernetworking/cni v0.6.0
 	github.com/containernetworking/plugins v0.6.0
 	github.com/coreos/etcd v3.3.25+incompatible
-	github.com/coreos/go-iptables v0.4.3 // indirect
-	github.com/emicklei/go-restful v2.15.0+incompatible // indirect
+	github.com/coreos/go-iptables v0.4.3
+	github.com/emicklei/go-restful v2.15.0+incompatible
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/fsouza/go-dockerclient v1.6.0
 	github.com/go-logr/logr v0.4.0

--- a/bcs-services/bcs-alert-manager/go.mod
+++ b/bcs-services/bcs-alert-manager/go.mod
@@ -3,13 +3,14 @@ module github.com/Tencent/bk-bcs/bcs-services/bcs-alert-manager
 go 1.14
 
 replace (
+	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210818040851-76fdc539dc33
 	github.com/coreos/bbolt v1.3.4 => go.etcd.io/bbolt v1.3.4
 	go.etcd.io/bbolt v1.3.4 => github.com/coreos/bbolt v1.3.4
 	google.golang.org/grpc => google.golang.org/grpc v1.26.0
 )
 
 require (
-	github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210128033108-0471fd5e2976
+	github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210818040851-76fdc539dc33
 	github.com/envoyproxy/protoc-gen-validate v0.1.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.4.3

--- a/bcs-services/bcs-clb-controller/go.mod
+++ b/bcs-services/bcs-clb-controller/go.mod
@@ -3,7 +3,7 @@ module github.com/Tencent/bk-bcs/bcs-services/bcs-clb-controller
 go 1.14
 
 replace (
-	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210517123645-82ef0026bf95
+	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210818040851-76fdc539dc33
 	github.com/Tencent/bk-bcs/bcs-k8s/kubedeprecated => github.com/Tencent/bk-bcs/bcs-k8s/kubedeprecated v0.0.0-20210517125505-0f40c4b365cb
 	github.com/Tencent/bk-bcs/bcs-mesos/kubebkbcsv2 => github.com/Tencent/bk-bcs/bcs-mesos/kubebkbcsv2 v0.0.0-20210517125505-0f40c4b365cb
 	github.com/coreos/bbolt v1.3.4 => go.etcd.io/bbolt v1.3.4

--- a/bcs-services/bcs-client/go.mod
+++ b/bcs-services/bcs-client/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 replace (
 	bitbucket.org/ww/goautoneg => github.com/adjust/goautoneg v0.0.0-20150426214442-d788f35a0315
-	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210625040556-0385f88cbfd6
+	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210818040851-76fdc539dc33
 	github.com/Tencent/bk-bcs/bcs-k8s/bcs-gamedeployment-operator => ../../bcs-k8s/bcs-gamedeployment-operator
 	github.com/Tencent/bk-bcs/bcs-k8s/bcs-gamestatefulset-operator => ../../bcs-k8s/bcs-gamestatefulset-operator
 	github.com/Tencent/bk-bcs/bcs-k8s/kubebkbcs => github.com/Tencent/bk-bcs/bcs-k8s/kubebkbcs v0.0.0-20210117140338-aeaed29b1997
@@ -14,7 +14,9 @@ replace (
 	github.com/Tencent/bk-bcs/bcs-services/bcs-webhook-server => ../../bcs-services/bcs-webhook-server
 	github.com/coreos/bbolt v1.3.4 => go.etcd.io/bbolt v1.3.4
 	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.0 // indirect
+	github.com/mholt/caddy => github.com/caddyserver/caddy v0.11.1
 	github.com/openshift/api => github.com/openshift/api v0.0.0-20180801171038-322a19404e37
+	github.com/tencentcloud/tencentcloud-sdk-go => github.com/tencentcloud/tencentcloud-sdk-go v1.0.132
 	github.com/ugorji/go v1.1.4 => github.com/ugorji/go v0.0.0-20181204163529-d75b2dcb6bc8
 	go.etcd.io/bbolt v1.3.4 => github.com/coreos/bbolt v1.3.4
 	google.golang.org/grpc => google.golang.org/grpc v1.26.0
@@ -29,66 +31,22 @@ replace (
 )
 
 require (
-	contrib.go.opencensus.io/exporter/prometheus v0.2.0 // indirect
-	fortio.org/fortio v1.6.3 // indirect
-	github.com/DATA-DOG/go-sqlmock v1.4.1 // indirect
-	github.com/Masterminds/sprig/v3 v3.1.0 // indirect
-	github.com/Masterminds/squirrel v1.2.0 // indirect
 	github.com/Tencent/bk-bcs v1.20.11
-	github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210223080803-f27f3f3c01c4
+	github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210818040851-76fdc539dc33
 	github.com/Tencent/bk-bcs/bcs-services/bcs-log-manager v0.0.0-00010101000000-000000000000
 	github.com/Tencent/bk-bcs/bcs-services/bcs-mesh-manager v0.0.0-00010101000000-000000000000
 	github.com/Tencent/bk-bcs/bcs-services/bcs-user-manager v0.0.0-00010101000000-000000000000
 	github.com/bitly/go-simplejson v0.5.0
-	github.com/census-instrumentation/opencensus-proto v0.3.0 // indirect
-	github.com/cheggaaa/pb/v3 v3.0.4 // indirect
-	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
-	github.com/containernetworking/cni v0.7.0-alpha1 // indirect
-	github.com/containernetworking/plugins v0.7.3 // indirect
-	github.com/coreos/go-oidc v2.2.1+incompatible // indirect
-	github.com/d4l3k/messagediff v1.2.1 // indirect
 	github.com/docker/docker v17.12.0-ce-rc1.0.20181223114339-d147fe0582f4+incompatible
-	github.com/dsnet/compress v0.0.1 // indirect
-	github.com/envoyproxy/go-control-plane v0.9.7-0.20200811182123-112a4904c4b0 // indirect
-	github.com/fatih/color v1.9.0 // indirect
 	github.com/ghodss/yaml v1.0.0
 	github.com/gogo/protobuf v1.3.2
-	github.com/golang/sync v0.0.0-20180314180146-1d60e4601c6f // indirect
 	github.com/gorilla/websocket v1.4.2
-	github.com/hashicorp/go-multierror v1.1.0 // indirect
-	github.com/hashicorp/vault/api v1.0.3 // indirect
-	github.com/howeyc/fsnotify v0.9.0 // indirect
-	github.com/jmoiron/sqlx v1.2.0 // indirect
-	github.com/kubernetes-client/go v0.0.0-20200222171647-9dac5e4c5400 // indirect
-	github.com/kylelemons/godebug v1.1.0 // indirect
-	github.com/lestrrat-go/jwx v1.0.3 // indirect
-	github.com/magiconair/properties v1.8.1 // indirect
-	github.com/mattn/go-shellwords v1.0.10 // indirect
-	github.com/mholt/archiver v3.1.1+incompatible // indirect
-	github.com/micro/go-micro/v2 v2.9.1 // indirect
 	github.com/miekg/dns v1.1.30 // indirect
 	github.com/moby/term v0.0.0-20200611042045-63b9a826fb74
-	github.com/natefinch/lumberjack v2.0.0+incompatible // indirect
-	github.com/nwaples/rardecode v1.1.0 // indirect
-	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus/tsdb v0.7.1 // indirect
-	github.com/rubenv/sql-migrate v0.0.0-20200212082348-64f95ea68aa3 // indirect
 	github.com/sirupsen/logrus v1.7.0
-	github.com/ulikunitz/xz v0.5.7 // indirect
 	github.com/urfave/cli v1.22.4
-	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
-	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
-	github.com/yl2chen/cidranger v1.0.0 // indirect
 	go.uber.org/zap v1.15.0 // indirect
-	google.golang.org/grpc v1.31.1
-	google.golang.org/grpc/examples v0.0.0-20200818224027-0f73133e3aa3 // indirect
-	gopkg.in/d4l3k/messagediff.v1 v1.2.1 // indirect
-	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
-	istio.io/api v0.0.0-20200819225923-c78f387f78a2 // indirect
-	istio.io/client-go v0.0.0-20200812230733-f5504d568313 // indirect
-	istio.io/gogo-genproto v0.0.0-20200720193312-b523a30fe746 // indirect
+	google.golang.org/grpc v1.31.0
 	k8s.io/apiextensions-apiserver v0.18.6
-	k8s.io/code-generator v0.19.0 // indirect
-	sigs.k8s.io/service-apis v0.0.0-20200731055707-56154e7bfde5 // indirect
 )

--- a/bcs-services/bcs-cluster-manager/go.mod
+++ b/bcs-services/bcs-cluster-manager/go.mod
@@ -3,7 +3,7 @@ module github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager
 go 1.14
 
 replace (
-	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210525083026-bc8c14258b6e // v0.20.16
+	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210818040851-76fdc539dc33
 	github.com/coreos/bbolt v1.3.4 => go.etcd.io/bbolt v1.3.4
 	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.0
 	go.etcd.io/bbolt v1.3.4 => github.com/coreos/bbolt v1.3.4
@@ -30,6 +30,7 @@ require (
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/micro/go-micro/v2 v2.9.1
 	github.com/prometheus/client_golang v1.9.0
+	go.mongodb.org/mongo-driver v1.5.3
 	golang.org/x/crypto v0.0.0-20200709230013-948cd5f35899 // indirect
 	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
 	google.golang.org/grpc v1.31.0

--- a/bcs-services/bcs-cluster-manager/internal/store/cluster/cluster.go
+++ b/bcs-services/bcs-cluster-manager/internal/store/cluster/cluster.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/store/options"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/store/util"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/types"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 const (
@@ -31,10 +32,10 @@ const (
 
 var (
 	clusterIndexes = []drivers.Index{
-		drivers.Index{
+		{
 			Name: clusterTableName + "_idx",
-			Key: map[string]int32{
-				"clusterID": 1,
+			Key: bson.D{
+				bson.E{Key: "clusterID", Value: 1},
 			},
 			Unique: true,
 		},

--- a/bcs-services/bcs-cluster-manager/internal/store/clustercredential/clustercredential.go
+++ b/bcs-services/bcs-cluster-manager/internal/store/clustercredential/clustercredential.go
@@ -23,6 +23,7 @@ import (
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/store/options"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/store/util"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/types"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 const (
@@ -32,10 +33,10 @@ const (
 
 var (
 	clusterCredentialIndexes = []drivers.Index{
-		drivers.Index{
+		{
 			Name: clusterCredentialTableName + "_idx",
-			Key: map[string]int32{
-				"serverKey": 1,
+			Key: bson.D{
+				bson.E{Key: "serverKey", Value: 1},
 			},
 			Unique: true,
 		},

--- a/bcs-services/bcs-cluster-manager/internal/store/namespace/namespace.go
+++ b/bcs-services/bcs-cluster-manager/internal/store/namespace/namespace.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/store/options"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/store/util"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/types"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 const (
@@ -33,11 +34,11 @@ const (
 
 var (
 	namespaceClusterIndexes = []drivers.Index{
-		drivers.Index{
+		{
 			Name: namespaceTableName + "_idx",
-			Key: map[string]int32{
-				"name":                1,
-				"federationClusterID": 1,
+			Key: bson.D{
+				bson.E{Key: "name", Value: 1},
+				bson.E{Key: "federationClusterID", Value: 1},
 			},
 			Unique: true,
 		},

--- a/bcs-services/bcs-cluster-manager/internal/store/namespacequota/namespacequota.go
+++ b/bcs-services/bcs-cluster-manager/internal/store/namespacequota/namespacequota.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/store/options"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/store/util"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/types"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 const (
@@ -36,10 +37,10 @@ var (
 	quotaIndexes = []drivers.Index{
 		drivers.Index{
 			Name: quotaTableName + "_idx",
-			Key: map[string]int32{
-				quotaKeyNamespace:           1,
-				quotaKeyFederationClusterID: 1,
-				quotaKeyClusterID:           1,
+			Key: bson.D{
+				bson.E{Key: quotaKeyNamespace, Value: 1},
+				bson.E{Key: quotaKeyFederationClusterID, Value: 1},
+				bson.E{Key: quotaKeyClusterID, Value: 1},
 			},
 			Unique: true,
 		},

--- a/bcs-services/bcs-cluster-manager/internal/store/tke/tke.go
+++ b/bcs-services/bcs-cluster-manager/internal/store/tke/tke.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/store/options"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/store/util"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/types"
+	"go.mongodb.org/mongo-driver/bson"
 )
 
 const (
@@ -31,11 +32,11 @@ const (
 
 var (
 	tkeCidrIndexes = []drivers.Index{
-		drivers.Index{
+		{
 			Name: tkeCidrTableName + "_idx",
-			Key: map[string]int32{
-				"vpc":  1,
-				"cidr": 1,
+			Key: bson.D{
+				bson.E{Key: "vpc", Value: 1},
+				bson.E{Key: "cidr", Value: 1},
 			},
 			Unique: true,
 		},
@@ -171,7 +172,7 @@ func (m *ModelTkeCidr) ListTkeCidr(ctx context.Context, cond *operator.Condition
 func (m *ModelTkeCidr) ListTkeCidrCount(ctx context.Context, opt *options.ListOption) ([]types.TkeCidrCount, error) {
 	retTkeCidrCountList := make([]types.TkeCidrCount, 0)
 	pipeline := []map[string]interface{}{
-		map[string]interface{}{
+		{
 			"$group": map[string]interface{}{
 				"_id": map[string]interface{}{
 					"vpc":      "$vpc",

--- a/bcs-services/bcs-gateway-discovery/go.mod
+++ b/bcs-services/bcs-gateway-discovery/go.mod
@@ -3,7 +3,7 @@ module github.com/Tencent/bk-bcs/bcs-services/bcs-gateway-discovery
 go 1.14
 
 replace (
-	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210517123645-82ef0026bf95
+	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210818040851-76fdc539dc33
 	github.com/coreos/bbolt v1.3.4 => go.etcd.io/bbolt v1.3.4
 	github.com/coreos/etcd => github.com/coreos/etcd v3.3.18+incompatible
 	github.com/kevholditch/gokong => github.com/DeveloperJim/gokong v1.9.2

--- a/bcs-services/bcs-log-manager/go.mod
+++ b/bcs-services/bcs-log-manager/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 replace (
 	bitbucket.org/ww/goautoneg => github.com/adjust/goautoneg v0.0.0-20150426214442-d788f35a0315
-	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210117140338-aeaed29b1997
+	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210818040851-76fdc539dc33
 	github.com/Tencent/bk-bcs/bcs-k8s/bcs-gamedeployment-operator => ../../bcs-k8s/bcs-gamedeployment-operator
 	github.com/Tencent/bk-bcs/bcs-k8s/bcs-gamestatefulset-operator => ../../bcs-k8s/bcs-gamestatefulset-operator
 	github.com/Tencent/bk-bcs/bcs-k8s/kubebkbcs => github.com/Tencent/bk-bcs/bcs-k8s/kubebkbcs v0.0.0-20210117140338-aeaed29b1997

--- a/bcs-services/bcs-logbeat-sidecar/go.mod
+++ b/bcs-services/bcs-logbeat-sidecar/go.mod
@@ -8,7 +8,7 @@ replace (
 )
 
 require (
-	github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210518090424-99527484a283
+	github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210818040851-76fdc539dc33
 	github.com/Tencent/bk-bcs/bcs-k8s/kubebkbcs v0.0.0-20210518090424-99527484a283
 	github.com/containerd/containerd v1.4.3 // indirect
 	github.com/docker/docker v20.10.0-rc1+incompatible // indirect

--- a/bcs-services/bcs-mesh-manager/go.mod
+++ b/bcs-services/bcs-mesh-manager/go.mod
@@ -3,7 +3,7 @@ module github.com/Tencent/bk-bcs/bcs-services/bcs-mesh-manager
 go 1.14
 
 require (
-	github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210117140338-aeaed29b1997
+	github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210818040851-76fdc539dc33
 	github.com/evanphx/json-patch v4.9.0+incompatible
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.2.0

--- a/bcs-services/bcs-user-manager/go.mod
+++ b/bcs-services/bcs-user-manager/go.mod
@@ -3,9 +3,10 @@ module github.com/Tencent/bk-bcs/bcs-services/bcs-user-manager
 go 1.14
 
 replace (
-	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210122122633-ada65fa64361
+	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210818040851-76fdc539dc33
 	github.com/coreos/bbolt v1.3.4 => go.etcd.io/bbolt v1.3.4
 	go.etcd.io/bbolt v1.3.4 => github.com/coreos/bbolt v1.3.4
+	google.golang.org/grpc => google.golang.org/grpc v1.26.0
 	k8s.io/api => k8s.io/api v0.0.0-20181126151915-b503174bad59
 	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20181126123746-eddba98df674
 	k8s.io/client-go => k8s.io/client-go v0.0.0-20181126152608-d082d5923d3c

--- a/bcs-services/bcs-webhook-server/go.mod
+++ b/bcs-services/bcs-webhook-server/go.mod
@@ -4,7 +4,7 @@ go 1.14
 
 replace (
 	bitbucket.org/ww/goautoneg => github.com/adjust/goautoneg v0.0.0-20150426214442-d788f35a0315
-	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210128145721-adb5c5c98979
+	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210818040851-76fdc539dc33
 	github.com/Tencent/bk-bcs/bcs-k8s/bcs-gamedeployment-operator => ../../bcs-k8s/bcs-gamedeployment-operator
 	github.com/Tencent/bk-bcs/bcs-k8s/bcs-gamestatefulset-operator => ../../bcs-k8s/bcs-gamestatefulset-operator
 	github.com/Tencent/bk-bcs/bcs-k8s/kubebkbcs => github.com/Tencent/bk-bcs/bcs-k8s/kubebkbcs v0.0.0-20210128145721-adb5c5c98979

--- a/bmsf-mesh/go.mod
+++ b/bmsf-mesh/go.mod
@@ -3,7 +3,7 @@ module github.com/Tencent/bk-bcs/bmsf-mesh
 go 1.14
 
 replace (
-	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210517123645-82ef0026bf95
+	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210818040851-76fdc539dc33
 	github.com/Tencent/bk-bcs/bcs-k8s/kubedeprecated => github.com/Tencent/bk-bcs/bcs-k8s/kubedeprecated v0.0.0-20210517125505-0f40c4b365cb
 	github.com/coreos/bbolt v1.3.4 => go.etcd.io/bbolt v1.3.4
 	go.etcd.io/bbolt v1.3.4 => github.com/coreos/bbolt v1.3.4

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Tencent/bk-bcs
 go 1.14
 
 replace (
-	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210701115224-9a3fe0620a49
+	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210818040851-76fdc539dc33
 	github.com/Tencent/bk-bcs/bcs-mesos/kubebkbcsv2 => github.com/Tencent/bk-bcs/bcs-mesos/kubebkbcsv2 v0.0.0-20210517125505-0f40c4b365cb
 	github.com/coreos/bbolt v1.3.4 => go.etcd.io/bbolt v1.3.4
 	github.com/haproxytech/client-native => github.com/abstractmj/client-native v1.2.8
@@ -16,9 +16,8 @@ replace (
 require (
 	github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
-	github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210701115224-9a3fe0620a49
+	github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210818040851-76fdc539dc33
 	github.com/Tencent/bk-bcs/bcs-mesos/kubebkbcsv2 v0.0.0-00010101000000-000000000000
-	github.com/andygrunwald/megos v0.0.0-20180424065632-0fccaea93714
 	github.com/bitly/go-simplejson v0.5.0
 	github.com/container-storage-interface/spec v0.3.0
 	github.com/containerd/continuity v0.0.0-20190827140505-75bee3e2ccb6 // indirect

--- a/install/conf/bcs-services/bcs-gateway-discovery/apisix-start.sh
+++ b/install/conf/bcs-services/bcs-gateway-discovery/apisix-start.sh
@@ -13,20 +13,17 @@ apisix start
 pid=`cat /usr/local/apisix/logs/nginx.pid`
 ps -efww | grep nginx
 
-#setting tls certification by json
-if [ "x${bcsSSLJSON}" == "x" ]; then
-  echo "lost apisix bkbcs SSL json"
-  exit 1
-fi
-
 echo "\n waiting for apisix initialization....(3s)"
 
 sleep 3
 
 echo "ready to registe api-gateway tls certification..."
 
+certContent=`cat ${apiGatewayCert} | sed ':label;N;s/\n/\\n/g;b label'`
+keyContent=`cat ${apiGatewayKey} | sed ':label;N;s/\n/\\n/g;b label'`
+
 curl -vv http://127.0.0.1:8000/apisix/admin/ssl/bkbcs \
-  -H"X-API-KEY: ${adminToken}" -X PUT -d@${bcsSSLJSON}
+  -H"X-API-KEY: ${adminToken}" -X PUT -d "{\"cert\":\"${certContent}\",\"key\":\"${keyContent}\",\"sni\":\"${ingressHostPattern}\"}"
 
 #signal trap
 echo "waiting for container exit signal~"

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 # zookeeper config
-export bcs_zk_client_user='bcsce'
-export bcs_zk_client_pwd='bcsce@community2019'
+export bcs_zk_client_user=''
+export bcs_zk_client_pwd=''
 
 # encryption config for community edition container release
-export bcs_encryption_key='!@#^&*()1qaz@WSX3ed84RFV'
+export bcs_encryption_key=''
 
 # cert password config
 export bcs_server_cert_pwd=''
@@ -13,5 +13,5 @@ export bcs_client_cert_pwd=''
 export bcs_license_server_client_cert_pwd=""
 
 # docker registry config
-export bcs_registry_default_user='bcsce'
-export bcs_registry_default_pwd='bcsce'
+export bcs_registry_default_user=''
+export bcs_registry_default_pwd=''


### PR DESCRIPTION
- 更新各模块所依赖 bcs-common 版本，支持社区无硬编译密码部署
- 按照安全要求删除仓库中的默认密码