### PR TITLE
bcs-logbeat-sidecar: add namespace isolation

### DIFF
--- a/bcs-services/bcs-logbeat-sidecar/app/app.go
+++ b/bcs-services/bcs-logbeat-sidecar/app/app.go
@@ -56,6 +56,7 @@ func setConfig(conf *config.Config, op *options.SidecarOption) {
 	conf.Kubeconfig = op.Kubeconfig
 	conf.EvalSymlink = op.EvalSymlink
 	conf.LogbeatPIDFilePath = op.LogbeatPIDFilePath
+	conf.IsNamespaceScope = op.IsNamespaceScope
 	conf.NeedReload = op.NeedReload
 	conf.LogbeatOutputFormat = op.LogbeatOutputFormat
 	if op.FileExtension == "" {

--- a/bcs-services/bcs-logbeat-sidecar/app/options/options.go
+++ b/bcs-services/bcs-logbeat-sidecar/app/options/options.go
@@ -38,6 +38,7 @@ type SidecarOption struct {
 	Kubeconfig          string `json:"kubeconfig" value:"" usage:"kubeconfig"`
 	EvalSymlink         bool   `json:"eval_symlink" value:"false" usage:"whether to enable remove symbol link in the log path"`
 	LogbeatPIDFilePath  string `json:"logbeat_pid_file_path" value:"" usage:"logbeat pid file path, which is used to reload logbeat"`
+	IsNamespaceScope    bool   `json:"is_namespace_scope" value:"" usage:"whether to enable 'BcsLogConfig' can only be associated with container in the same namespace"`
 }
 
 //NewSidecarOption create SidecarOption object

--- a/bcs-services/bcs-logbeat-sidecar/config/config.go
+++ b/bcs-services/bcs-logbeat-sidecar/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	NeedReload          bool
 	FileExtension       string
 	LogbeatOutputFormat string
+	IsNamespaceScope    bool
 }
 
 //NewConfig create a config object

--- a/bcs-services/bcs-logbeat-sidecar/sidecar/logconfig_unsupport.go
+++ b/bcs-services/bcs-logbeat-sidecar/sidecar/logconfig_unsupport.go
@@ -1,0 +1,31 @@
+// +build !windows,!linux
+
+/*
+* Tencent is pleased to support the open source community by making Blueking Container Service available.
+* Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+* Licensed under the MIT License (the "License"); you may not use this file except
+* in compliance with the License. You may obtain a copy of the License at
+* http://opensource.org/licenses/MIT
+* Unless required by applicable law or agreed to in writing, software distributed under
+* the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+* either express or implied. See the License for the specific language governing permissions and
+* limitations under the License.
+*
+ */
+
+package sidecar
+
+import (
+	"github.com/Tencent/bk-bcs/bcs-common/common/blog"
+	docker "github.com/fsouza/go-dockerclient"
+)
+
+func (s *SidecarController) reloadLogbeat() error {
+	blog.Warnf("not supported platform")
+	return nil
+}
+
+func (s *SidecarController) getActualPath(logPath string, container *docker.Container) (string, error) {
+	blog.Warnf("not supported platform")
+	return "", nil
+}

--- a/bcs-services/bcs-logbeat-sidecar/sidecar/logconfop_linux.go
+++ b/bcs-services/bcs-logbeat-sidecar/sidecar/logconfop_linux.go
@@ -1,4 +1,5 @@
 // +build linux
+
 /*
 * Tencent is pleased to support the open source community by making Blueking Container Service available.
 * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.

--- a/bcs-services/bcs-logbeat-sidecar/sidecar/logconfop_windows.go
+++ b/bcs-services/bcs-logbeat-sidecar/sidecar/logconfop_windows.go
@@ -1,4 +1,5 @@
 // +build windows
+
 /*
 * Tencent is pleased to support the open source community by making Blueking Container Service available.
 * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.


### PR DESCRIPTION
为bcs-logbeat-sidecar组件增加ns隔离，改动：
- 增加了is_namespace_scope参数进行控制
- 只获取pod namespace内的bcslogconfig配置
- 忽略workloadNamespace参数

同时增加了一个`logconfig_unsupport.go` 文件，避免mac ide下提示错误。