### PR TITLE
bcs-k8s-watch: 增加namespace隔离

### DIFF
--- a/bcs-services/bcs-k8s-watch/app/k8s/manager.go
+++ b/bcs-services/bcs-k8s-watch/app/k8s/manager.go
@@ -19,16 +19,15 @@ import (
 
 	glog "github.com/Tencent/bk-bcs/bcs-common/common/blog"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-k8s-watch/app/bcs"
+	"github.com/Tencent/bk-bcs/bcs-services/bcs-k8s-watch/app/k8s/resources"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-k8s-watch/app/options"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-k8s-watch/app/output"
-	clientGoCache "k8s.io/client-go/tools/cache"
-
-	"github.com/Tencent/bk-bcs/bcs-services/bcs-k8s-watch/app/k8s/resources"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-k8s-watch/app/output/action"
 	apiextensionsV1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	crdClientSet "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	clientGoCache "k8s.io/client-go/tools/cache"
 )
 
 // WatcherManager is resource watcher manager.
@@ -51,13 +50,14 @@ type WatcherManager struct {
 
 	// id of current cluster.
 	clusterID string
-
+	// namespaces 指定监听的namespace资源，暂时单个
+	watchResource *options.WatchResource
 	// target storage service.
 	storageService *bcs.InnerService
 }
 
 // NewWatcherManager creates a new WatcherManager instance.
-func NewWatcherManager(clusterID string, writer *output.Writer, k8sConfig *options.K8sConfig,
+func NewWatcherManager(clusterID string, watchResource *options.WatchResource, writer *output.Writer, k8sConfig *options.K8sConfig,
 	storageService, netservice *bcs.InnerService, sc <-chan struct{}) (*WatcherManager, error) {
 
 	mgr := &WatcherManager{
@@ -67,10 +67,11 @@ func NewWatcherManager(clusterID string, writer *output.Writer, k8sConfig *optio
 		writer:         writer,
 		clusterID:      clusterID,
 		storageService: storageService,
+		watchResource:  watchResource,
 	}
 	mgr.initWatchers(clusterID, k8sConfig, storageService, netservice)
 
-	mgr.synchronizer = NewSynchronizer(clusterID, mgr.watchers, mgr.crdWatchers, storageService)
+	mgr.synchronizer = NewSynchronizer(clusterID, watchResource.Namespace, mgr.watchers, mgr.crdWatchers, storageService)
 	return mgr, nil
 }
 
@@ -84,35 +85,39 @@ func (mgr *WatcherManager) initWatchers(clusterID string,
 
 	// init k8s normal resource watchers
 	for name, resourceObjType := range resources.WatcherConfigList {
-		watcher := NewWatcher(resourceObjType.Client, name, resourceObjType.ResourceName, resourceObjType.ObjType, mgr.writer, mgr.watchers, resourceObjType.Namespaced) // nolint
+		watcher := NewWatcher(resourceObjType.Client, mgr.watchResource.Namespace, name, resourceObjType.ResourceName, resourceObjType.ObjType, mgr.writer, mgr.watchers, resourceObjType.Namespaced) // nolint
 		mgr.watchers[name] = watcher
 	}
 
-	// begin to watch kubefed to init kubefed watchers
-	crdClient, err := crdClientSet.NewForConfig(restConfig)
-	if err != nil {
-		panic(err)
+	if !mgr.watchResource.DisableCRD {
+		// begin to watch kubefed to init kubefed watchers
+		crdClient, err := crdClientSet.NewForConfig(restConfig)
+		if err != nil {
+			panic(err)
+		}
+		crdInformerFactory := externalversions.NewSharedInformerFactory(crdClient, time.Second*30)
+		crdInformer := crdInformerFactory.Apiextensions().V1beta1().CustomResourceDefinitions()
+		crdInformer.Lister()
+
+		crdInformer.Informer().AddEventHandler(clientGoCache.ResourceEventHandlerFuncs{
+			AddFunc:    mgr.AddEvent,
+			UpdateFunc: mgr.UpdateEvent,
+			DeleteFunc: mgr.DeleteEvent,
+		})
+
+		go crdInformerFactory.Start(mgr.stopChan)
+
+		glog.Infof("Waiting for informer caches to sync")
+		if ok := clientGoCache.WaitForCacheSync(mgr.stopChan, crdInformer.Informer().HasSynced); !ok {
+			err := fmt.Errorf("failed to wait for kubefed caches to sync")
+			panic(err)
+		}
 	}
-	crdInformerFactory := externalversions.NewSharedInformerFactory(crdClient, time.Second*30)
-	crdInformer := crdInformerFactory.Apiextensions().V1beta1().CustomResourceDefinitions()
-	crdInformer.Lister()
 
-	crdInformer.Informer().AddEventHandler(clientGoCache.ResourceEventHandlerFuncs{
-		AddFunc:    mgr.AddEvent,
-		UpdateFunc: mgr.UpdateEvent,
-		DeleteFunc: mgr.DeleteEvent,
-	})
-
-	go crdInformerFactory.Start(mgr.stopChan)
-
-	glog.Infof("Waiting for informer caches to sync")
-	if ok := clientGoCache.WaitForCacheSync(mgr.stopChan, crdInformer.Informer().HasSynced); !ok {
-		err := fmt.Errorf("failed to wait for kubefed caches to sync")
-		panic(err)
+	if !mgr.watchResource.DisableNetservice {
+		// init netservice watcher.
+		mgr.netserviceWatcher = NewNetServiceWatcher(clusterID, storageService, netservice)
 	}
-
-	// init netservice watcher.
-	mgr.netserviceWatcher = NewNetServiceWatcher(clusterID, storageService, netservice)
 }
 
 func (mgr *WatcherManager) AddEvent(obj interface{}) {
@@ -160,7 +165,7 @@ func (mgr *WatcherManager) runCrdWatcher(obj *apiextensionsV1beta1.CustomResourc
 		mgr.writer.Handlers[obj.Spec.Names.Kind].Run(stopChan)
 
 		// init and run watcher
-		watcher := NewWatcher(&kubefedClient, obj.Spec.Names.Kind, obj.Spec.Names.Plural, runtimeObject, mgr.writer, mgr.watchers, namespaced) // nolint
+		watcher := NewWatcher(&kubefedClient, mgr.watchResource.Namespace, obj.Spec.Names.Kind, obj.Spec.Names.Plural, runtimeObject, mgr.writer, mgr.watchers, namespaced) // nolint
 		watcher.stopChan = stopChan
 		mgr.crdWatchers[obj.Spec.Names.Kind] = watcher
 		glog.Infof("watcher manager, start list-watcher[%+v]", obj.Spec.Names.Kind)
@@ -189,9 +194,10 @@ func (mgr *WatcherManager) Run(stopCh <-chan struct{}) {
 		go watcher.Run(stopCh)
 	}
 
-	// run netservice watcher.
-	go mgr.netserviceWatcher.Run(stopCh)
-
+	if !mgr.watchResource.DisableNetservice {
+		// run netservice watcher.
+		go mgr.netserviceWatcher.Run(stopCh)
+	}
 	// run synchronizer.
 	go mgr.synchronizer.Run(stopCh)
 }

--- a/bcs-services/bcs-k8s-watch/app/k8s/watcher.go
+++ b/bcs-services/bcs-k8s-watch/app/k8s/watcher.go
@@ -69,10 +69,11 @@ type Watcher struct {
 	writer             *output.Writer
 	sharedWatchers     map[string]WatcherInterface
 	stopChan           chan struct{}
+	namespace          string
 }
 
 // NewWatcher creates a new watcher of target type resource.
-func NewWatcher(client *rest.Interface, resourceType string, resourceName string, objType runtime.Object,
+func NewWatcher(client *rest.Interface, namespace string, resourceType string, resourceName string, objType runtime.Object,
 	writer *output.Writer, sharedWatchers map[string]WatcherInterface, resourceNamespaced bool) *Watcher {
 
 	watcher := &Watcher{
@@ -81,10 +82,11 @@ func NewWatcher(client *rest.Interface, resourceType string, resourceName string
 		sharedWatchers:     sharedWatchers,
 		resourceNamespaced: resourceNamespaced,
 		queue:              queue.New(),
+		namespace:          namespace,
 	}
 
 	// build list watch.
-	listWatch := cache.NewListWatchFromClient(*client, resourceName, metav1.NamespaceAll, fields.Everything())
+	listWatch := cache.NewListWatchFromClient(*client, resourceName, namespace, fields.Everything())
 
 	// register event handler.
 	eventHandler := cache.ResourceEventHandlerFuncs{

--- a/bcs-services/bcs-k8s-watch/app/options/options.go
+++ b/bcs-services/bcs-k8s-watch/app/options/options.go
@@ -28,8 +28,7 @@ type DefaultConfig struct {
 	Environment string `json:"environment"`
 	// ClusterID is only used when CluterIDSource was set to "config"
 	ClusterID string `json:"clusterID"`
-
-	HostIP string `json:"hostIP"`
+	HostIP    string `json:"hostIP"`
 }
 
 // validate validates DefaultConfig and set proper default values
@@ -72,8 +71,17 @@ type BCSConfig struct {
 
 // K8sConfig for installation out of cluster
 type K8sConfig struct {
-	Master string `json:"master"`
-	TLS    TLS    `json:"tls"`
+	Kubeconfig string `json:"kubeconfig"`
+	Master     string `json:"master"`
+	TLS        TLS    `json:"tls"`
+}
+
+// WatchResource 指定监听的资源
+type WatchResource struct {
+	//监听指定的namespace，暂时支持一个
+	Namespace         string `json:"namespace"`
+	DisableCRD        bool   `json:"disable_crd"`
+	DisableNetservice bool   `json:"disable_netservice"`
 }
 
 // WatchConfig k8s-watch config
@@ -82,6 +90,7 @@ type WatchConfig struct {
 	BCS              BCSConfig     `json:"bcs"`
 	K8s              K8sConfig     `json:"k8s"`
 	FilterConfigPath string        `json:"filterConfigPath"`
+	WatchResource    WatchResource `json:"watch_resource"`
 	conf.FileConfig
 	conf.ProcessConfig
 	conf.LogConfig

--- a/bcs-services/bcs-k8s-watch/go.mod
+++ b/bcs-services/bcs-k8s-watch/go.mod
@@ -2,32 +2,11 @@ module github.com/Tencent/bk-bcs/bcs-services/bcs-k8s-watch
 
 go 1.14
 
-//
-//replace (
-//	bitbucket.org/ww/goautoneg => github.com/adjust/goautoneg v0.0.0-20150426214442-d788f35a0315
-//	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210818040851-76fdc539dc33
-//	github.com/Tencent/bk-bcs/bcs-k8s/bcs-gamedeployment-operator => ../../bcs-runtime/bcs-k8s/bcs-component/bcs-gamedeployment-operator
-//	github.com/Tencent/bk-bcs/bcs-k8s/bcs-gamestatefulset-operator => ../../bcs-runtime/bcs-k8s/bcs-component/bcs-gamestatefulset-operator
-//	github.com/Tencent/bk-bcs/bcs-k8s/kubebkbcs => github.com/Tencent/bk-bcs/bcs-k8s/kubebkbcs v0.0.0-20210117140338-aeaed29b1997
-//	github.com/Tencent/bk-bcs/bcs-mesos/kubebkbcsv2 => github.com/Tencent/bk-bcs/bcs-mesos/kubebkbcsv2 v0.0.0-20210117140338-aeaed29b1997
-//	github.com/coreos/bbolt v1.3.4 => go.etcd.io/bbolt v1.3.4
-//	github.com/go-logr/logr => github.com/go-logr/logr v0.1.0
-//	github.com/googleapis/gnostic => github.com/googleapis/gnostic v0.4.0 // indirect
-//	go.etcd.io/bbolt v1.3.4 => github.com/coreos/bbolt v1.3.4
-//	google.golang.org/grpc => google.golang.org/grpc v1.26.0
-//	k8s.io/api => k8s.io/api v0.0.0-20181126151915-b503174bad59
-//	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-20181126155829-0cd23ebeb688
-//	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20181126123746-eddba98df674
-//	k8s.io/client-go => k8s.io/client-go v0.0.0-20181126152608-d082d5923d3c
-//	k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20181109181836-c59034cc13d5
-//	k8s.io/kubernetes => k8s.io/kubernetes v1.13.1
-//)
-
 replace (
 	bitbucket.org/ww/goautoneg => github.com/adjust/goautoneg v0.0.0-20150426214442-d788f35a0315
-	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210117140338-aeaed29b1997
-	github.com/Tencent/bk-bcs/bcs-k8s/bcs-gamedeployment-operator => ../../bcs-runtime/bcs-k8s/bcs-component/bcs-gamedeployment-operator
-	github.com/Tencent/bk-bcs/bcs-k8s/bcs-gamestatefulset-operator => ../../bcs-runtime/bcs-k8s/bcs-component/bcs-gamestatefulset-operator
+	github.com/Tencent/bk-bcs/bcs-common => github.com/Tencent/bk-bcs/bcs-common v0.0.0-20210818040851-76fdc539dc33
+	github.com/Tencent/bk-bcs/bcs-k8s/bcs-gamedeployment-operator => ../../bcs-k8s/bcs-gamedeployment-operator
+	github.com/Tencent/bk-bcs/bcs-k8s/bcs-gamestatefulset-operator => ../../bcs-k8s/bcs-gamestatefulset-operator
 	github.com/Tencent/bk-bcs/bcs-k8s/kubebkbcs => github.com/Tencent/bk-bcs/bcs-k8s/kubebkbcs v0.0.0-20210117140338-aeaed29b1997
 	github.com/Tencent/bk-bcs/bcs-mesos/kubebkbcsv2 => github.com/Tencent/bk-bcs/bcs-mesos/kubebkbcsv2 v0.0.0-20210117140338-aeaed29b1997
 	github.com/coreos/bbolt v1.3.4 => go.etcd.io/bbolt v1.3.4

--- a/install/conf/bcs-services/bcs-k8s-watch/Dockerfile
+++ b/install/conf/bcs-services/bcs-k8s-watch/Dockerfile
@@ -13,6 +13,12 @@ ADD filter.json /data/bcs/bcs-k8s-watch/
 RUN chmod +x /data/bcs/bcs-k8s-watch/bcs-k8s-watch
 RUN chmod +x /data/bcs/bcs-k8s-watch/container-start.sh
 
+# 提前设置的默认env
+# 关闭netservice的数据上报，默认关闭
+ENV watchDisableNetService=false
+# 关闭crd资源的数据上报，默认关闭
+ENV watchDisableCrd=false
+
 ENV TZ="Asia/Shanghai"
 RUN ln -fs /usr/share/zoneinfo/${TZ} /etc/localtime && echo ${TZ} > /etc/timezone
 

--- a/install/conf/bcs-services/bcs-k8s-watch/bcs-k8s-watch.json.template
+++ b/install/conf/bcs-services/bcs-k8s-watch/bcs-k8s-watch.json.template
@@ -3,6 +3,11 @@
         "clusterID": "${clusterId}",
         "hostIP": "${localIp}"
     },
+     "watch_resource": {
+        "namespace": "${watchNamespace}",
+        "disable_netservice": ${watchDisableNetService},
+        "disable_crd": ${watchDisableCrd}
+    },
     "bcs": {
         "zk": "${bcsZkHost}",
         "tls": {
@@ -19,6 +24,7 @@
         "podQueueNum": ${podQueueNum}
     },
     "k8s": {
+        "kubeconfig": "${kubeconfig}",
         "master": "${kubeMaster}",
         "tls": {
             "ca-file": "",


### PR DESCRIPTION
- 增加`watch_resource.namespace`参数，监听指定ns
- 增加`watch_resource.watchDisableNetService`参数，用于设置关闭netservice数据上报
- 增加`watch_resource.watchDisableCrd`，用于设置关闭crd资源的数据上报
- 增加了一个`kubeconfig`参数，方便在容器中监听外部集群
