### PR TITLE
fix: enable gamestatefulset scheme default setting

### DIFF
--- a/bcs-runtime/bcs-k8s/bcs-component/bcs-gamestatefulset-operator/pkg/controllers/game_stateful_set.go
+++ b/bcs-runtime/bcs-k8s/bcs-component/bcs-gamestatefulset-operator/pkg/controllers/game_stateful_set.go
@@ -575,6 +575,9 @@ func (ssc *GameStatefulSetController) sync(key string) (retErr error) {
 		return err
 	}
 
+	// set default value, call Default() function will invoke scheme's defaulterFuncs
+	scheme.Scheme.Default(set)
+
 	selector, err := metav1.LabelSelectorAsSelector(set.Spec.Selector)
 	if err != nil {
 		utilruntime.HandleError(fmt.Errorf("error converting GameStatefulSet %v selector: %v", key, err))


### PR DESCRIPTION
修复 gamestatefulset 对象默认值失效的问题，默认值失效会导致未设置 `spec.updateStrategy.type` 时，不能以 `OnDelete` 策略创建新 Pod。