### PR TITLE
解决bcs-webhook-server的依赖问题

### DIFF
--- a/bcs-runtime/bcs-k8s/kubebkbcs/apis/tkex/v1alpha1/gamestatefulset_types.go
+++ b/bcs-runtime/bcs-k8s/kubebkbcs/apis/tkex/v1alpha1/gamestatefulset_types.go
@@ -271,8 +271,8 @@ type GameStatefulSetCondition struct {
 
 // GameStatefulSet compatible with original StatefulSet but support in-place update additionally
 // +genclient
-// +genclient:method=GetScale,verb=get,subresource=scale,result=k8s.io/kubernetes/pkg/apis/autoscaling.Scale
-// +genclient:method=UpdateScale,verb=update,subresource=scale,input=k8s.io/kubernetes/pkg/apis/autoscaling.Scale,result=k8s.io/kubernetes/pkg/apis/autoscaling.Scale
+// +genclient:method=GetScale,verb=get,subresource=scale,result=k8s.io/api/autoscaling/v1.Scale
+// +genclient:method=UpdateScale,verb=update,subresource=scale,input=k8s.io/api/autoscaling/v1.Scale,result=k8s.io/api/autoscaling/v1.Scale
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:printcolumn:JSONPath=.spec.replicas,name=Replicas,type=integer
 // +kubebuilder:printcolumn:JSONPath=.status.readyReplicas,name=Ready_Replicas,type=integer

--- a/bcs-runtime/bcs-k8s/kubebkbcs/generated/clientset/versioned/typed/tkex/v1alpha1/fake/fake_gamestatefulset.go
+++ b/bcs-runtime/bcs-k8s/kubebkbcs/generated/clientset/versioned/typed/tkex/v1alpha1/fake/fake_gamestatefulset.go
@@ -24,7 +24,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
-	autoscaling "k8s.io/kubernetes/pkg/apis/autoscaling"
+	autoscaling "k8s.io/api/autoscaling/v1"
 )
 
 // FakeGameStatefulSets implements GameStatefulSetInterface

--- a/bcs-runtime/bcs-k8s/kubebkbcs/generated/clientset/versioned/typed/tkex/v1alpha1/gamestatefulset.go
+++ b/bcs-runtime/bcs-k8s/kubebkbcs/generated/clientset/versioned/typed/tkex/v1alpha1/gamestatefulset.go
@@ -24,7 +24,7 @@ import (
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
-	autoscaling "k8s.io/kubernetes/pkg/apis/autoscaling"
+	autoscaling "k8s.io/api/autoscaling/v1"
 )
 
 // GameStatefulSetsGetter has a method to return a GameStatefulSetInterface.

--- a/bcs-runtime/bcs-k8s/kubebkbcs/go.mod
+++ b/bcs-runtime/bcs-k8s/kubebkbcs/go.mod
@@ -3,8 +3,9 @@ module github.com/Tencent/bk-bcs/bcs-runtime/bcs-k8s/kubebkbcs
 go 1.14
 
 require (
-	k8s.io/api v0.18.5
-	k8s.io/apimachinery v0.18.5
-	k8s.io/code-generator v0.18.5
+	k8s.io/api v0.20.0
+	k8s.io/apimachinery v0.20.0
+	k8s.io/client-go v0.20.0
+	k8s.io/code-generator v0.20.0
 	sigs.k8s.io/controller-runtime v0.6.0
 )


### PR DESCRIPTION
bcs-runtime/bcs-k8s/kubebkbcs依赖的k8s版本升级到0.20.0，与gameworkload保持一致