### PR TITLE
feat: support pod lb weight annotation

### DIFF
--- a/bcs-runtime/bcs-k8s/kubernetes/apis/networkextension/v1/ingress_types.go
+++ b/bcs-runtime/bcs-k8s/kubernetes/apis/networkextension/v1/ingress_types.go
@@ -40,6 +40,10 @@ const (
 	WorkloadKindStatefulset = "statefulset"
 	// WorkloadKindGameStatefulset kind name of workload game statefulset
 	WorkloadKindGameStatefulset = "gamestatefulset"
+
+	// Pod CLB weight annotation key
+	AnnotationKeyForLoadbalanceWeight      = "networkextension.bkbcs.tencent.com/clb-weight"
+	AnnotationKeyForLoadbalanceWeightReady = "networkextension.bkbcs.tencent.com/clb-weight-ready"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!


### PR DESCRIPTION
支持 pod annotation 配置 lb 后端服务权重，需要是直通模式。

annotation 示例：
```
networkextension.bkbcs.tencent.com/clb-weight: "20"
```

配置完成后，会给 pod 添加 annotation `networkextension.bkbcs.tencent.com/clb-weight-ready: "true"`。