### PR TITLE
为BCS GPA添加 Grafana dashboard

### DIFF
--- a/docs/features/prometheus/bcs-k8s/bcs-general-pod-autoscaler的监测指标.md
+++ b/docs/features/prometheus/bcs-k8s/bcs-general-pod-autoscaler的监测指标.md
@@ -1,0 +1,77 @@
+# bcs-general-pod-autoscaler的prom指标
+
+指标详情可参考prom指标定义文件：
+
+bk-bcs/bcs-runtime/bcs-k8s/bcs-component/bcs-general-pod-autoscaler/pkg/metrics/prometheus_metrics.go
+
+## 指标说明
+
+### 指标中各label的含义
+
+| 标签名       | 含义                                                         |
+| :----------- | ------------------------------------------------------------ |
+| namespace    | gpa所在的命名空间                                            |
+| name         | gpa名称                                                      |
+| metric       | metric模式下指缩放参考指标名称(如cpu、memory)；webhook模式下指service的namespace/name或url；time模式下指的是具体的schedule |
+| scaledObject | 被缩放的对象(kind/name)                                      |
+| scaler       | 缩放模式类型(metric,webhook,time等)                          |
+
+### 指标含义
+
+#### keda_metrics_adapter_scaler_errors_total
+
+- 所有scaler的错误总数
+
+#### keda_metrics_adapter_scaler_errors
+
+- 单个scaler的错误数量
+- labels：namespace,name, scaledObject, scaler, metric
+
+#### keda_metrics_adapter_scaled_object_errors
+
+- 被缩放对象的错误数量
+- labels：namespace,name, scaledObject
+
+#### keda_metrics_adapter_scaler_target_metrics_value
+
+在metric模式下，该指标的含义：
+
+- gpa中设定的参考指标的值
+- labels：namespace,name, scaledObject, scaler, metric
+
+在webhook/time模式下，该指标的含义：
+
+- 相应模式下推荐的副本数
+- labels：namespace,name, scaledObject, scaler, metric
+
+#### keda_metrics_adapter_scaler_current_metrics_value
+
+在metric模式下，该指标的含义：
+
+- 参考指标当前的数值
+- labels：namespace,name, scaledObject, scaler, metric
+
+在webhook/time模式下，该指标的含义：
+
+- 被缩放对象当前的副本数
+- labels：namespace,name, scaledObject, scaler, metric
+
+#### keda_metrics_adapter_scaler_desired_replicas_value
+
+- 相应模式下推荐的副本数
+- labels：namespace,name, scaledObject, scaler
+
+#### keda_metrics_adapter_gpa_desired_replicas_value
+
+- gpa推荐的副本数
+- labels：namespace,name, scaledObject
+
+#### keda_metrics_adapter_gpa_min_replicas_value
+
+- gpa设置的最小副本数
+- labels: namespace,name, scaledObject
+
+#### keda_metrics_adapter_gpa_max_replicas_value
+
+- gpa设置的最大副本数
+- labels: namespace,name, scaledObject

--- a/docs/features/prometheus/bcs-k8s/bcs-general-pod-autoscaler的监测指标.md
+++ b/docs/features/prometheus/bcs-k8s/bcs-general-pod-autoscaler的监测指标.md
@@ -20,7 +20,7 @@ bk-bcs/bcs-runtime/bcs-k8s/bcs-component/bcs-general-pod-autoscaler/pkg/metrics/
 
 #### keda_metrics_adapter_scaler_errors_total
 
-- 所有scaler的错误总数
+- 所有scaler的错误总数
 
 #### keda_metrics_adapter_scaler_errors
 

--- a/docs/features/prometheus/grafana/bcs-general-pod-autoscaler.json
+++ b/docs/features/prometheus/grafana/bcs-general-pod-autoscaler.json
@@ -1,0 +1,800 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 25,
+  "iteration": 1645590480086,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 19,
+      "panels": [],
+      "title": "报错相关",
+      "type": "row"
+    },
+    {
+      "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 10,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.4",
+      "targets": [
+        {
+          "expr": "rate(keda_metrics_adapter_scaler_errors_total{instance=~\"$instance\"}[3m]) ",
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "3分钟报错率",
+      "type": "stat"
+    },
+    {
+      "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "last"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "7.3.4",
+      "targets": [
+        {
+          "expr": "keda_metrics_adapter_scaler_errors_total{instance=~\"$instance\"}",
+          "interval": "",
+          "legendFormat": "",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "GPA获取metric报错总数",
+      "type": "stat"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "decimals": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "hiddenSeries": false,
+      "id": 4,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "keda_metrics_adapter_scaled_object_errors{namespace=~\"$namespace\",name=~\"$name\",instance=~\"$instance\"}",
+          "interval": "",
+          "legendFormat": "{{scaledObject}}",
+          "queryType": "randomWalk",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "被缩放对象的报错数量",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 17
+      },
+      "id": 17,
+      "panels": [],
+      "title": "副本数、CPU & memory",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "decimals": 0,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sort": "current",
+        "sortDesc": false,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "keda_metrics_adapter_scaler_desired_replicas_value{namespace=~\"$namespace\",name=~\"$name\",instance=~\"$instance\"}",
+          "format": "time_series",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "legendFormat": "scalerDesired - {{namespace}}/{{name}}",
+          "queryType": "randomWalk",
+          "refId": "A"
+        },
+        {
+          "expr": "keda_metrics_adapter_gpa_max_replicas_value{namespace=~\"$namespace\",name=~\"$name\",instance=~\"$instance\"}",
+          "interval": "",
+          "legendFormat": "Max - {{namespace}}/{{name}}",
+          "refId": "B"
+        },
+        {
+          "expr": "keda_metrics_adapter_gpa_min_replicas_value{namespace=~\"$namespace\",name=~\"$name\",instance=~\"$instance\"}",
+          "interval": "",
+          "legendFormat": "Min - {{namespace}}/{{name}}",
+          "refId": "C"
+        },
+        {
+          "expr": "keda_metrics_adapter_gpa_desired_replicas_value{namespace=~\"$namespace\",name=~\"$name\",instance=~\"$instance\"}",
+          "interval": "",
+          "legendFormat": "gpaDesired - {{namespace}}/{{name}}",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "GPA副本数",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "decimals": 2,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "hiddenSeries": false,
+      "id": 13,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sideWidth": -2,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "keda_metrics_adapter_scaler_current_metrics_value{namespace=~\"$namespace\",name=~\"$name\",metric=\"memory\",instance=~\"$instance\"}",
+          "interval": "",
+          "legendFormat": "Current - {{namespace}}/{{name}}",
+          "queryType": "randomWalk",
+          "refId": "A"
+        },
+        {
+          "expr": "keda_metrics_adapter_scaler_target_metrics_value{namespace=~\"$namespace\",name=~\"$name\",metric=\"memory\",instance=~\"$instance\"}",
+          "interval": "",
+          "legendFormat": "Target - {{namespace}}/{{name}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "memory指标",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "hiddenSeries": false,
+      "id": 12,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.3.4",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "keda_metrics_adapter_scaler_current_metrics_value{namespace=~\"$namespace\",name=~\"$name\",metric=\"cpu\",instance=~\"$instance\"}",
+          "interval": "",
+          "legendFormat": "current - {{namespace}}/{{name}}",
+          "queryType": "randomWalk",
+          "refId": "A"
+        },
+        {
+          "expr": "keda_metrics_adapter_scaler_target_metrics_value{namespace=~\"$namespace\",name=~\"$name\",metric=\"cpu\",instance=~\"$instance\"}",
+          "interval": "",
+          "legendFormat": "target - {{namespace}}/{{name}}",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "CPU指标",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": "CPU使用率",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "schemaVersion": 26,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": [
+            "default"
+          ],
+          "value": [
+            "default"
+          ]
+        },
+        "datasource": "prometheus",
+        "definition": "label_values(keda_metrics_adapter_scaler_target_metrics_value{namespace=~\".*\"},namespace)",
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": "",
+        "multi": true,
+        "name": "namespace",
+        "options": [],
+        "query": "label_values(keda_metrics_adapter_scaler_target_metrics_value{namespace=~\".*\"},namespace)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": [
+            "pa-test1"
+          ],
+          "value": [
+            "pa-test1"
+          ]
+        },
+        "datasource": "prometheus",
+        "definition": "label_values({__name__ =~ \"keda_metrics_adapter_scaler_target_metrics_value|keda_metrics_adapter_scaler_errors\", namespace=~\"$namespace\"},name)\n",
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": "",
+        "multi": true,
+        "name": "name",
+        "options": [],
+        "query": "label_values({__name__ =~ \"keda_metrics_adapter_scaler_target_metrics_value|keda_metrics_adapter_scaler_errors\", namespace=~\"$namespace\"},name)\n",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "prometheus",
+        "definition": "label_values(keda_metrics_adapter_scaler_target_metrics_value{namespace=~\"$namespace\",name=~\"$name\",scaledObject=~\".*\"},scaledObject)",
+        "error": null,
+        "hide": 2,
+        "includeAll": true,
+        "label": "",
+        "multi": true,
+        "name": "scaledObject",
+        "options": [],
+        "query": "label_values(keda_metrics_adapter_scaler_target_metrics_value{namespace=~\"$namespace\",name=~\"$name\",scaledObject=~\".*\"},scaledObject)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": [
+            "10.244.2.67:10251"
+          ],
+          "value": [
+            "10.244.2.67:10251"
+          ]
+        },
+        "datasource": "prometheus",
+        "definition": "label_values(keda_metrics_adapter_scaler_errors_total,instance)",
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": "label_values(keda_metrics_adapter_scaler_errors_total,instance)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": false,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": "prometheus",
+        "definition": "label_values(keda_metrics_adapter_scaler_errors_total{endpoint=~\".*\"},endpoint)",
+        "error": null,
+        "hide": 2,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "endpoint",
+        "options": [],
+        "query": "label_values(keda_metrics_adapter_scaler_errors_total{endpoint=~\".*\"},endpoint)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-2m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "GPA Dashboard",
+  "uid": "D1ibIqank",
+  "version": 38
+}

--- a/docs/features/prometheus/grafana/bcs-general-pod-autoscaler.json
+++ b/docs/features/prometheus/grafana/bcs-general-pod-autoscaler.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 25,
-  "iteration": 1645590480086,
+  "iteration": 1645673958757,
   "links": [],
   "panels": [
     {
@@ -79,7 +79,7 @@
       "pluginVersion": "7.3.4",
       "targets": [
         {
-          "expr": "rate(keda_metrics_adapter_scaler_errors_total{instance=~\"$instance\"}[3m]) ",
+          "expr": "rate(keda_metrics_adapter_scaler_errors_total{}[3m]) ",
           "interval": "",
           "legendFormat": "",
           "queryType": "randomWalk",
@@ -137,7 +137,7 @@
       "pluginVersion": "7.3.4",
       "targets": [
         {
-          "expr": "keda_metrics_adapter_scaler_errors_total{instance=~\"$instance\"}",
+          "expr": "keda_metrics_adapter_scaler_errors_total{}",
           "interval": "",
           "legendFormat": "",
           "queryType": "randomWalk",
@@ -216,7 +216,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "keda_metrics_adapter_scaled_object_errors{namespace=~\"$namespace\",name=~\"$name\",instance=~\"$instance\"}",
+          "expr": "keda_metrics_adapter_scaled_object_errors{namespace=~\"$namespace\",name=~\"$name\",scaledObject=~\"$scaledObject\"}",
           "interval": "",
           "legendFormat": "{{scaledObject}}",
           "queryType": "randomWalk",
@@ -346,7 +346,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "keda_metrics_adapter_scaler_desired_replicas_value{namespace=~\"$namespace\",name=~\"$name\",instance=~\"$instance\"}",
+          "expr": "keda_metrics_adapter_scaler_desired_replicas_value{namespace=~\"$namespace\",name=~\"$name\",scaledObject=~\"$scaledObject\"}",
           "format": "time_series",
           "hide": false,
           "instant": false,
@@ -356,19 +356,19 @@
           "refId": "A"
         },
         {
-          "expr": "keda_metrics_adapter_gpa_max_replicas_value{namespace=~\"$namespace\",name=~\"$name\",instance=~\"$instance\"}",
+          "expr": "keda_metrics_adapter_gpa_max_replicas_value{namespace=~\"$namespace\",name=~\"$name\",scaledObject=~\"$scaledObject\"}",
           "interval": "",
           "legendFormat": "Max - {{namespace}}/{{name}}",
           "refId": "B"
         },
         {
-          "expr": "keda_metrics_adapter_gpa_min_replicas_value{namespace=~\"$namespace\",name=~\"$name\",instance=~\"$instance\"}",
+          "expr": "keda_metrics_adapter_gpa_min_replicas_value{namespace=~\"$namespace\",name=~\"$name\",scaledObject=~\"$scaledObject\"}",
           "interval": "",
           "legendFormat": "Min - {{namespace}}/{{name}}",
           "refId": "C"
         },
         {
-          "expr": "keda_metrics_adapter_gpa_desired_replicas_value{namespace=~\"$namespace\",name=~\"$name\",instance=~\"$instance\"}",
+          "expr": "keda_metrics_adapter_gpa_desired_replicas_value{namespace=~\"$namespace\",name=~\"$name\",scaledObject=~\"$scaledObject\"}",
           "interval": "",
           "legendFormat": "gpaDesired - {{namespace}}/{{name}}",
           "refId": "D"
@@ -634,13 +634,10 @@
       {
         "allValue": null,
         "current": {
-          "selected": false,
-          "text": [
-            "default"
-          ],
-          "value": [
-            "default"
-          ]
+          "selected": true,
+          "tags": [],
+          "text": [],
+          "value": []
         },
         "datasource": "prometheus",
         "definition": "label_values(keda_metrics_adapter_scaler_target_metrics_value{namespace=~\".*\"},namespace)",
@@ -665,13 +662,10 @@
       {
         "allValue": null,
         "current": {
-          "selected": false,
-          "text": [
-            "pa-test1"
-          ],
-          "value": [
-            "pa-test1"
-          ]
+          "selected": true,
+          "tags": [],
+          "text": [],
+          "value": []
         },
         "datasource": "prometheus",
         "definition": "label_values({__name__ =~ \"keda_metrics_adapter_scaler_target_metrics_value|keda_metrics_adapter_scaler_errors\", namespace=~\"$namespace\"},name)\n",
@@ -696,24 +690,21 @@
       {
         "allValue": null,
         "current": {
-          "selected": false,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
+          "selected": true,
+          "tags": [],
+          "text": [],
+          "value": []
         },
         "datasource": "prometheus",
-        "definition": "label_values(keda_metrics_adapter_scaler_target_metrics_value{namespace=~\"$namespace\",name=~\"$name\",scaledObject=~\".*\"},scaledObject)",
+        "definition": "label_values({__name__ =~ \"keda_metrics_adapter_scaler_target_metrics_value|keda_metrics_adapter_scaler_errors\", namespace=~\"$namespace\",name=~\"$name\"},scaledObject)",
         "error": null,
-        "hide": 2,
+        "hide": 0,
         "includeAll": true,
         "label": "",
         "multi": true,
         "name": "scaledObject",
         "options": [],
-        "query": "label_values(keda_metrics_adapter_scaler_target_metrics_value{namespace=~\"$namespace\",name=~\"$name\",scaledObject=~\".*\"},scaledObject)",
+        "query": "label_values({__name__ =~ \"keda_metrics_adapter_scaler_target_metrics_value|keda_metrics_adapter_scaler_errors\", namespace=~\"$namespace\",name=~\"$name\"},scaledObject)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -727,7 +718,7 @@
       {
         "allValue": null,
         "current": {
-          "selected": false,
+          "selected": true,
           "text": [
             "10.244.2.67:10251"
           ],
@@ -738,7 +729,7 @@
         "datasource": "prometheus",
         "definition": "label_values(keda_metrics_adapter_scaler_errors_total,instance)",
         "error": null,
-        "hide": 0,
+        "hide": 2,
         "includeAll": true,
         "label": null,
         "multi": true,
@@ -758,7 +749,7 @@
       {
         "allValue": null,
         "current": {
-          "selected": false,
+          "selected": true,
           "text": [
             "All"
           ],
@@ -796,5 +787,5 @@
   "timezone": "",
   "title": "GPA Dashboard",
   "uid": "D1ibIqank",
-  "version": 38
+  "version": 41
 }


### PR DESCRIPTION
### 为BCS GPA添加 Grafana dashboard

- 定义namespace,name,instance变量，可以筛选具体的gpa实例进行查看

![WX20220223-135553](https://user-images.githubusercontent.com/45477075/155268417-179f54b4-ccba-4792-bed9-5c9319012201.png)

- gpa相关报错指标

![WX20220223-111630](https://user-images.githubusercontent.com/45477075/155268106-1585be6a-990e-4601-a1fb-27a264d9a1ab.png)

- gpa副本数，metric模式下cpu和memory相关指标数据

![WX20220223-110853](https://user-images.githubusercontent.com/45477075/155268139-8b4b44cc-de5b-4eba-b405-df679038adc4.png)

