### PR TITLE
fix: 共享集群页面，切换集群时，展示的集群和切换的集群不一致

### DIFF
--- a/bcs-ui/frontend/src/views/configuration/namespace.vue
+++ b/bcs-ui/frontend/src/views/configuration/namespace.vue
@@ -34,7 +34,8 @@
                             :search-scope.sync="searchScope"
                             :cluster-fixed="!!curClusterId"
                             @search="fetchNamespaceList"
-                            @refresh="refresh">
+                            @refresh="refresh"
+                            :key="isSharedCluster">
                         </bk-data-searcher>
                     </div>
                 </div>
@@ -677,7 +678,7 @@
             curClusterId () {
                 this.searchScope = this.curClusterId
                 this.clusterId = this.curClusterId
-                this.handleSearch()
+                this.fetchNamespaceList()
             }
         },
         async created () {


### PR DESCRIPTION
fix: 共享集群页面，切换集群时，展示的集群和切换的集群不一致