### PR TITLE
feat: add swagger2.0 docs for go-restful server.

### DIFF
--- a/bcs-common/common/http/httpserver/server.go
+++ b/bcs-common/common/http/httpserver/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Tencent/bk-bcs/bcs-common/common/blog"
 	"github.com/Tencent/bk-bcs/bcs-common/common/ssl"
 	"github.com/emicklei/go-restful"
+	restfulspec "github.com/emicklei/go-restful-openapi"
 	"github.com/gorilla/mux"
 	"net"
 	"net/http"
@@ -85,6 +86,19 @@ func (s *HttpServer) RegisterWebServer(rootPath string, filters []restful.Filter
 	//register action
 	s.RegisterActions(ws, actions)
 
+	return nil
+}
+
+// RegisterApiDocs register api docs
+func (s *HttpServer) RegisterApiDocs(apidocsPath string) error {
+	if apidocsPath == "" {
+		apidocsPath = "/apidocs.json"
+	}
+	config := restfulspec.Config{
+		WebServices: s.webContainer.RegisteredWebServices(),
+		APIPath:     apidocsPath,
+	}
+	s.webContainer.Add(restfulspec.NewOpenAPIService(config))
 	return nil
 }
 

--- a/bcs-common/go.mod
+++ b/bcs-common/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/docker/engine-api v0.4.0
 	github.com/elazarl/goproxy v0.0.0-20210110162100-a92cc753f88e // indirect
 	github.com/emicklei/go-restful v2.15.0+incompatible
+	github.com/emicklei/go-restful-openapi v1.4.1 // indirect
 	github.com/envoyproxy/protoc-gen-validate v0.1.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-sql-driver/mysql v1.5.0


### PR DESCRIPTION
Using go-restful-openapi to add swagger2.0.docs. 