### PR TITLE
fix: bcs mesos cluster metrics calc reserve 2 decimal

### DIFF
--- a/bcs-runtime/bcs-mesos/bcs-scheduler/src/manager/store/etcd/store.go
+++ b/bcs-runtime/bcs-mesos/bcs-scheduler/src/manager/store/etcd/store.go
@@ -358,7 +358,7 @@ func (s *managerStore) StartStoreObjectMetrics() {
 }
 
 func float2Float(num float64) float64 {
-	float_num, _ := strconv.ParseFloat(fmt.Sprintf("%.1f", num), 64)
+	float_num, _ := strconv.ParseFloat(fmt.Sprintf("%.2f", num), 64)
 	return float_num
 }
 

--- a/bcs-runtime/bcs-mesos/bcs-scheduler/src/manager/store/zk/store.go
+++ b/bcs-runtime/bcs-mesos/bcs-scheduler/src/manager/store/zk/store.go
@@ -229,7 +229,7 @@ func (s *managerStore) StartStoreObjectMetrics() {
 }
 
 func float2Float(num float64) float64 {
-	float_num, _ := strconv.ParseFloat(fmt.Sprintf("%.1f", num), 64)
+	float_num, _ := strconv.ParseFloat(fmt.Sprintf("%.2f", num), 64)
 	return float_num
 }
 


### PR DESCRIPTION
例如 44.44 会取 44.4
        44.45 会取 44.5

这个差距不稳定，100个节点极限值：少了 4c，多了 5c