### PR TITLE
feat: support lb reusable

### DIFF
--- a/bcs-runtime/bcs-k8s/bcs-network/Makefile
+++ b/bcs-runtime/bcs-k8s/bcs-network/Makefile
@@ -95,3 +95,9 @@ ipres-webhook:
 	cp -R ${BCS_CONF_NETWORK_PATH}/bcs-ipres-webhook/* ${INNER_PACKAGEPATH}/bcs-network/bcs-ipres-webhook
 	GOOS=linux go build ${LDFLAG} -o ${INNER_PACKAGEPATH}/bcs-network/bcs-ipres-webhook/bcs-ipres-webhook ./bcs-ipres-webhook/main.go
 	GOOS=linux go build ${LDFLAG} -o ${INNER_PACKAGEPATH}/bcs-network/bcs-ipres-webhook/bcs-ipres-nslabel-injector ./bcs-ipres-webhook/nslabelinjector/main.go
+
+# unit test for bcs ingress controller
+test-ingress-controller:
+	@go test -v -coverprofile=./bcs-ingress-controller/.coverage.out ./bcs-ingress-controller/...
+	@go tool cover -func=./bcs-ingress-controller/.coverage.out | tail -n1 | awk '{print "Total test coverage: " $$3}'
+	@go tool cover -html=./bcs-ingress-controller/.coverage.out -o ./bcs-ingress-controller/coverage.html

--- a/bcs-runtime/bcs-k8s/bcs-network/bcs-ingress-controller/internal/common/common.go
+++ b/bcs-runtime/bcs-k8s/bcs-network/bcs-ingress-controller/internal/common/common.go
@@ -13,6 +13,7 @@
 package common
 
 import (
+	"crypto/md5"
 	"fmt"
 	"strconv"
 	"strings"
@@ -25,6 +26,10 @@ import (
 func GetLbRegionAndName(lbName string) (string, string, error) {
 	if a, err := arn.Parse(lbName); err == nil {
 		return a.Region, lbName, nil
+	}
+	// for lb name without region, we use default region
+	if !strings.Contains(lbName, constant.DelimiterForLbID) {
+		return "", lbName, nil
 	}
 	idStrs := strings.Split(lbName, constant.DelimiterForLbID)
 	if len(idStrs) != 2 {
@@ -84,4 +89,11 @@ func GetSegmentListenerName(lbID string, startPort, endPort int) string {
 // GetNamespacedNameKey get key by name and namespace
 func GetNamespacedNameKey(name, ns string) string {
 	return name + "/" + ns
+}
+
+// GetPortPoolListenerLabelKey get key for port pool listener label
+// example: pool1/md5(item1)
+// because item1 is an anomaly string, so we use md5 to encode it
+func GetPortPoolListenerLabelKey(portPoolName, itemName string) string {
+	return portPoolName + "/" + fmt.Sprintf("%x", (md5.Sum([]byte(itemName))))
 }

--- a/bcs-runtime/bcs-k8s/bcs-network/bcs-ingress-controller/internal/portpoolcache/poolcache_test.go
+++ b/bcs-runtime/bcs-k8s/bcs-network/bcs-ingress-controller/internal/portpoolcache/poolcache_test.go
@@ -56,7 +56,7 @@ func TestCacheAllocate(t *testing.T) {
 	}
 	expectItem := AllocatedPortItem{
 		PoolKey:     "test1.ns1",
-		PoolItemKey: "lb1,lb2",
+		PoolItemKey: networkextensionv1.GetPoolItemKey("item1", []string{"lb1", "lb2"}),
 		Protocol:    "TCP",
 		StartPort:   30000,
 		EndPort:     0,
@@ -72,7 +72,7 @@ func TestCacheAllocate(t *testing.T) {
 	}
 	expectItem = AllocatedPortItem{
 		PoolKey:     "test1.ns1",
-		PoolItemKey: "lb1,lb2",
+		PoolItemKey: networkextensionv1.GetPoolItemKey("item1", []string{"lb1", "lb2"}),
 		Protocol:    "TCP",
 		StartPort:   30001,
 		EndPort:     0,
@@ -82,7 +82,7 @@ func TestCacheAllocate(t *testing.T) {
 		t.Fatalf("expect %v, but get %v", expectItem, cachePortItem)
 	}
 
-	cache.ReleasePortBinding("test1.ns1", "lb1,lb2", "TCP", 30001, 0)
+	cache.ReleasePortBinding("test1.ns1", networkextensionv1.GetPoolItemKey("item1", []string{"lb1", "lb2"}), "TCP", 30001, 0)
 
 	if cache.portPoolMap["test1.ns1"].ItemList[0].PortListMap["TCP"].AllocatedPortNum != 1 {
 		t.Fatalf("allocated port number %d is not 1",
@@ -104,7 +104,7 @@ func TestDeletePortPoolItem(t *testing.T) {
 		EndPort:         31000,
 		Status:          constant.PortBindingStatusReady,
 	}
-	cache.DeletePortPoolItem("test1.ns1", "lb1,lb2")
+	cache.DeletePortPoolItem("test1.ns1", networkextensionv1.GetPoolItemKey("item1", []string{"lb1", "lb2"}))
 	if !reflect.DeepEqual(cache.portPoolMap["test1.ns1"].ItemList[0].ItemStatus, testItem) {
 		t.Fatalf("expect %v but get %v", testItem, cache.portPoolMap["test1.ns1"].ItemList[0].ItemStatus)
 	}
@@ -117,14 +117,14 @@ func TestSetPortBindingUsed(t *testing.T) {
 		t.Fatalf("failed to get new cache")
 	}
 
-	cache.SetPortBindingUsed("test1.ns1", "lb1,lb2", "TCP", 30000, 0)
+	cache.SetPortBindingUsed("test1.ns1", networkextensionv1.GetPoolItemKey("item1", []string{"lb1", "lb2"}), "TCP", 30000, 0)
 	_, cachePortItem, err := cache.AllocatePortBinding("test1.ns1", "TCP")
 	if err != nil {
 		t.Fatalf("allocate port binding failed, err %s", err.Error())
 	}
 	expectItem := AllocatedPortItem{
 		PoolKey:     "test1.ns1",
-		PoolItemKey: "lb1,lb2",
+		PoolItemKey: networkextensionv1.GetPoolItemKey("item1", []string{"lb1", "lb2"}),
 		Protocol:    "TCP",
 		StartPort:   30001,
 		EndPort:     0,
@@ -141,11 +141,11 @@ func TestIsItemExisted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get new cache")
 	}
-	if !cache.IsItemExisted("test1.ns1", "lb1,lb2") {
-		t.Fatalf("pool test1.ns1, item lb1,lb2 should be existed")
+	if !cache.IsItemExisted("test1.ns1", networkextensionv1.GetPoolItemKey("item1", []string{"lb1", "lb2"})) {
+		t.Fatalf("pool test1.ns1, item item1-lb1,lb2 should be existed")
 	}
-	if cache.IsItemExisted("test1.ns1", "lb1,lb22") {
-		t.Fatalf("pool test1.ns1, item lb1,lb2 should not be existed")
+	if cache.IsItemExisted("test1.ns1", "item1-lb1,lb22") {
+		t.Fatalf("pool test1.ns1, item item1-lb1,lb2 should not be existed")
 	}
 }
 
@@ -156,7 +156,7 @@ func TestAllocateAllProtocolPortBinding(t *testing.T) {
 		t.Fatalf("failed to get new cache")
 	}
 
-	cache.SetPortBindingUsed("test1.ns1", "lb1,lb2", "TCP", 30000, 0)
+	cache.SetPortBindingUsed("test1.ns1", networkextensionv1.GetPoolItemKey("item1", []string{"lb1", "lb2"}), "TCP", 30000, 0)
 	_, mapItem, err := cache.AllocateAllProtocolPortBinding("test1.ns1")
 	if err != nil {
 		t.Fatalf("allocate port binding failed, err %s", err.Error())
@@ -164,7 +164,7 @@ func TestAllocateAllProtocolPortBinding(t *testing.T) {
 	expectMap := map[string]AllocatedPortItem{
 		"TCP": {
 			PoolKey:     "test1.ns1",
-			PoolItemKey: "lb1,lb2",
+			PoolItemKey: networkextensionv1.GetPoolItemKey("item1", []string{"lb1", "lb2"}),
 			Protocol:    "TCP",
 			StartPort:   30001,
 			EndPort:     0,
@@ -172,7 +172,7 @@ func TestAllocateAllProtocolPortBinding(t *testing.T) {
 		},
 		"UDP": {
 			PoolKey:     "test1.ns1",
-			PoolItemKey: "lb1,lb2",
+			PoolItemKey: networkextensionv1.GetPoolItemKey("item1", []string{"lb1", "lb2"}),
 			Protocol:    "UDP",
 			StartPort:   30001,
 			EndPort:     0,

--- a/bcs-runtime/bcs-k8s/bcs-network/bcs-ingress-controller/internal/webhookserver/annotationparse_test.go
+++ b/bcs-runtime/bcs-k8s/bcs-network/bcs-ingress-controller/internal/webhookserver/annotationparse_test.go
@@ -83,7 +83,7 @@ func TestParserAnnotation(t *testing.T) {
 			exceptedError: fmt.Errorf("protocol %s is invalid", ""),
 		},
 		{
-			name:  "mutil port",
+			name:  "mutil port in one line",
 			value: "portpool1.ns1 TCP 8000;portpool1.ns1 UDP 8000;portpool2.ns1 TCP 8080",
 			annotationPorts: []*annotationPort{
 				{
@@ -156,7 +156,7 @@ func TestParserAnnotation(t *testing.T) {
 	for _, s := range tests {
 		t.Run(s.name, func(t *testing.T) {
 			annotationPorts, err := parserAnnotation(s.value)
-			if !reflect.DeepEqual(err, s.exceptedError) {
+			if !isSameError(err, s.exceptedError) {
 				t.Errorf("parserAnnotation(%s) error, excepted: %v, actual: %v", s.value, s.exceptedError, err)
 			}
 			if !reflect.DeepEqual(annotationPorts, s.annotationPorts) {
@@ -164,4 +164,17 @@ func TestParserAnnotation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func isSameError(err1, err2 error) bool {
+	if err1 != nil && err2 == nil {
+		return false
+	}
+	if err1 == nil && err2 != nil {
+		return false
+	}
+	if err1 != nil && err2 != nil && err1.Error() != err2.Error() {
+		return false
+	}
+	return true
 }

--- a/bcs-runtime/bcs-k8s/bcs-network/bcs-ingress-controller/internal/webhookserver/validate.go
+++ b/bcs-runtime/bcs-k8s/bcs-network/bcs-ingress-controller/internal/webhookserver/validate.go
@@ -17,6 +17,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/Tencent/bk-bcs/bcs-common/common/blog"
+	"github.com/Tencent/bk-bcs/bcs-runtime/bcs-k8s/bcs-network/bcs-ingress-controller/internal/common"
 	"github.com/Tencent/bk-bcs/bcs-runtime/bcs-k8s/bcs-network/bcs-ingress-controller/internal/constant"
 	networkextensionv1 "github.com/Tencent/bk-bcs/bcs-runtime/bcs-k8s/kubernetes/apis/networkextension/v1"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
@@ -53,14 +55,15 @@ func (s *Server) validatePortPool(newPool *networkextensionv1.PortPool) error {
 	if err := s.checkPortPoolConflicts(newPool); err != nil {
 		return err
 	}
-	if err := s.checkPortPoolConflictWithIngress(newPool); err != nil {
+	if err := s.checkPortPoolConflictWithPort(newPool); err != nil {
 		return err
 	}
 	return nil
 }
 
 func (s *Server) checkPortPool(newPool *networkextensionv1.PortPool) error {
-	lbIDMap := make(map[string]string)
+	// key: lbID-port, value: itemName
+	lbPortMap := make(map[string]string)
 	itemNameMap := make(map[string]struct{})
 	for _, item := range newPool.Spec.PoolItems {
 		if err := item.Validate(); err != nil {
@@ -86,13 +89,16 @@ func (s *Server) checkPortPool(newPool *networkextensionv1.PortPool) error {
 			if err != nil {
 				return fmt.Errorf("lbIDStr %s of item %s is invalid", lbIDStr, item.ItemName)
 			}
-			if itemName, ok := lbIDMap[lbID]; ok {
-				return fmt.Errorf("lbID %s of item %s conflicts with id of item %s", lbID, item.ItemName, itemName)
+			for port := item.StartPort; port < item.EndPort; port++ {
+				lbPort := fmt.Sprintf("%s-%d", lbID, port)
+				if itemName, ok := lbPortMap[lbPort]; ok {
+					return fmt.Errorf("lbID %s of item %s conflicts with id of item %s", lbID, item.ItemName, itemName)
+				}
+				if arn.IsARN(lbID) {
+					isARN = true
+				}
+				lbPortMap[lbPort] = item.ItemName
 			}
-			if arn.IsARN(lbID) {
-				isARN = true
-			}
-			lbIDMap[lbID] = item.ItemName
 		}
 
 		// check protocol
@@ -129,15 +135,6 @@ func (s *Server) checkPortPoolChanges(newPool, oldPool *networkextensionv1.PortP
 				lbIDMap[lbID] = oldItem.ItemName
 			}
 		}
-		for _, lbIDStr := range newItem.LoadBalancerIDs {
-			lbID, err := getLbIDFromRegionID(lbIDStr)
-			if err != nil {
-				return fmt.Errorf("lbIDStr %s of item %s is invalid", newItem.ItemName, lbIDStr)
-			}
-			if oldItemName, ok := lbIDMap[lbID]; ok {
-				return fmt.Errorf("lbID %s of item %s conflicts with item %s", lbID, newItem.ItemName, oldItemName)
-			}
-		}
 	}
 	return nil
 }
@@ -148,7 +145,8 @@ func (s *Server) checkPortPoolConflicts(newPool *networkextensionv1.PortPool) er
 		return fmt.Errorf("list port pool list failed, err %s", err.Error())
 	}
 
-	lbIDMap := make(map[string]string)
+	// key: lb-port, value: existedPoolNamespaceName
+	lbPortMap := make(map[string]string)
 	for _, existedPool := range portPoolList.Items {
 		if newPool.GetName() == existedPool.GetName() && newPool.GetNamespace() == existedPool.GetNamespace() {
 			continue
@@ -159,7 +157,10 @@ func (s *Server) checkPortPoolConflicts(newPool *networkextensionv1.PortPool) er
 				if err != nil {
 					return fmt.Errorf("lbIDStr %s of existed item %s is invalid", item.ItemName, lbIDStr)
 				}
-				lbIDMap[lbID] = existedPool.GetName() + "/" + existedPool.GetNamespace()
+				for port := item.StartPort; port < item.EndPort; port++ {
+					lbPort := fmt.Sprintf("%s-%d", lbID, port)
+					lbPortMap[lbPort] = existedPool.GetName() + "/" + existedPool.GetNamespace()
+				}
 			}
 		}
 	}
@@ -170,9 +171,12 @@ func (s *Server) checkPortPoolConflicts(newPool *networkextensionv1.PortPool) er
 			if err != nil {
 				return fmt.Errorf("lbIDStr %s of new item %s is invalid", newItem.ItemName, lbIDStr)
 			}
-			if existedPoolKey, ok := lbIDMap[lbID]; ok {
-				return fmt.Errorf("lbID %s of new item %s is conflict with pool %s",
-					lbID, newItem.ItemName, existedPoolKey)
+			for port := newItem.StartPort; port < newItem.EndPort; port++ {
+				lbPort := fmt.Sprintf("%s-%d", lbID, port)
+				if existedPoolKey, ok := lbPortMap[lbPort]; ok {
+					return fmt.Errorf("lbID %s of new item %s is conflict with pool %s",
+						lbID, newItem.ItemName, existedPoolKey)
+				}
 			}
 		}
 	}
@@ -210,5 +214,52 @@ func (s *Server) checkPortPoolConflictWithIngress(newPool *networkextensionv1.Po
 			}
 		}
 	}
+	return nil
+}
+
+// this function is used to check portpool's port conflicts with ingress or other portpool
+func (s *Server) checkPortPoolConflictWithPort(newPool *networkextensionv1.PortPool) error {
+	existedListeners := &networkextensionv1.ListenerList{}
+	err := s.k8sClient.List(context.Background(), existedListeners, &client.ListOptions{})
+	if err != nil {
+		blog.Errorf("list existed listener failed, err %s", err.Error())
+		return fmt.Errorf("list existed listener failed, err %s", err.Error())
+	}
+
+	// use lbid-port as key of map for check conflicts
+	existedListenerMap := make(map[string]networkextensionv1.Listener)
+	for index, listener := range existedListeners.Items {
+		// listener for port segment
+		if listener.Spec.EndPort > 0 {
+			for i := listener.Spec.Port; i <= listener.Spec.EndPort; i++ {
+				tmpKey := common.GetListenerName(listener.Spec.LoadbalancerID, i)
+				existedListenerMap[tmpKey] = existedListeners.Items[index]
+			}
+			continue
+		}
+		tmpKey := common.GetListenerName(listener.Spec.LoadbalancerID, listener.Spec.Port)
+		existedListenerMap[tmpKey] = existedListeners.Items[index]
+	}
+
+	// check port pool every port
+	for _, v := range newPool.Spec.PoolItems {
+		for i := v.StartPort; i < v.EndPort; i++ {
+			for _, lb := range v.LoadBalancerIDs {
+				tmpKey := common.GetListenerName(lb, int(i))
+				existedListener, ok := existedListenerMap[tmpKey]
+				if !ok {
+					continue
+				}
+
+				// check self
+				poolNameValue, okListenerLabel := existedListener.Labels[common.GetPortPoolListenerLabelKey(newPool.Name, v.ItemName)]
+				if !okListenerLabel || poolNameValue != networkextensionv1.LabelValueForPortPoolItemName ||
+					newPool.Namespace != existedListener.GetNamespace() {
+					return fmt.Errorf("lbID %s port %d of item %s is conflict", lb, i, v.ItemName)
+				}
+			}
+		}
+	}
+
 	return nil
 }

--- a/bcs-runtime/bcs-k8s/bcs-network/bcs-ingress-controller/internal/webhookserver/validate.go
+++ b/bcs-runtime/bcs-k8s/bcs-network/bcs-ingress-controller/internal/webhookserver/validate.go
@@ -90,7 +90,7 @@ func (s *Server) checkPortPool(newPool *networkextensionv1.PortPool) error {
 				return fmt.Errorf("lbIDStr %s of item %s is invalid", lbIDStr, item.ItemName)
 			}
 			for port := item.StartPort; port < item.EndPort; port++ {
-				lbPort := fmt.Sprintf("%s-%d", lbID, port)
+				lbPort := common.GetListenerName(lbID, int(port))
 				if itemName, ok := lbPortMap[lbPort]; ok {
 					return fmt.Errorf("lbID %s of item %s conflicts with id of item %s", lbID, item.ItemName, itemName)
 				}
@@ -158,7 +158,7 @@ func (s *Server) checkPortPoolConflicts(newPool *networkextensionv1.PortPool) er
 					return fmt.Errorf("lbIDStr %s of existed item %s is invalid", item.ItemName, lbIDStr)
 				}
 				for port := item.StartPort; port < item.EndPort; port++ {
-					lbPort := fmt.Sprintf("%s-%d", lbID, port)
+					lbPort := common.GetListenerName(lbID, int(port))
 					lbPortMap[lbPort] = existedPool.GetName() + "/" + existedPool.GetNamespace()
 				}
 			}
@@ -172,7 +172,7 @@ func (s *Server) checkPortPoolConflicts(newPool *networkextensionv1.PortPool) er
 				return fmt.Errorf("lbIDStr %s of new item %s is invalid", newItem.ItemName, lbIDStr)
 			}
 			for port := newItem.StartPort; port < newItem.EndPort; port++ {
-				lbPort := fmt.Sprintf("%s-%d", lbID, port)
+				lbPort := common.GetListenerName(lbID, int(port))
 				if existedPoolKey, ok := lbPortMap[lbPort]; ok {
 					return fmt.Errorf("lbID %s of new item %s is conflict with pool %s",
 						lbID, newItem.ItemName, existedPoolKey)

--- a/bcs-runtime/bcs-k8s/bcs-network/bcs-ingress-controller/portpoolcontroller/portpool.go
+++ b/bcs-runtime/bcs-k8s/bcs-network/bcs-ingress-controller/portpoolcontroller/portpool.go
@@ -115,10 +115,8 @@ func (pph *PortPoolHandler) ensurePortPool(pool *networkextensionv1.PortPool) (b
 			updateItemStatus, retry = poolItemHandler.ensurePortPoolItem(tmpItem, nil)
 			newItemStatusList = append(newItemStatusList, updateItemStatus)
 		} else {
-			if tmpItemStatus.Status != constant.PortPoolItemStatusReady || tmpItem.EndPort > tmpItemStatus.EndPort {
-				updateItemStatus, retry = poolItemHandler.ensurePortPoolItem(tmpItem, tmpItemStatus)
-				updateItemStatusMap[updateItemStatus.GetKey()] = updateItemStatus
-			}
+			updateItemStatus, retry = poolItemHandler.ensurePortPoolItem(tmpItem, tmpItemStatus)
+			updateItemStatusMap[updateItemStatus.GetKey()] = updateItemStatus
 		}
 		if retry {
 			shouldRetry = true

--- a/bcs-runtime/bcs-k8s/kubernetes/apis/networkextension/v1/listener_types.go
+++ b/bcs-runtime/bcs-k8s/kubernetes/apis/networkextension/v1/listener_types.go
@@ -37,6 +37,8 @@ const (
 	LabelValueTrue = "true"
 	// LabelValueFalse label value for false
 	LabelValueFalse = "false"
+	// LabelValueForPortPoolItemName label value for port pool and item name
+	LabelValueForPortPoolItemName = "portpool-item-name"
 	// ListenerStatusNotSynced shows listener changes are not synced
 	ListenerStatusNotSynced = "NotSynced"
 	// ListenerStatusSynced shows listener changes are synced

--- a/bcs-runtime/bcs-k8s/kubernetes/apis/networkextension/v1/portpool_types.go
+++ b/bcs-runtime/bcs-k8s/kubernetes/apis/networkextension/v1/portpool_types.go
@@ -42,10 +42,7 @@ type PortPoolItem struct {
 
 // GetKey get port pool item key
 func (ppi *PortPoolItem) GetKey() string {
-	tmpIDs := make([]string, len(ppi.LoadBalancerIDs))
-	copy(tmpIDs, ppi.LoadBalancerIDs)
-	sort.Strings(tmpIDs)
-	return strings.Join(tmpIDs, ",")
+	return GetPoolItemKey(ppi.ItemName, ppi.LoadBalancerIDs)
 }
 
 // Validate do validation
@@ -85,10 +82,15 @@ type PortPoolItemStatus struct {
 
 // GetKey get port pool item key
 func (ppis *PortPoolItemStatus) GetKey() string {
-	tmpIDs := make([]string, len(ppis.LoadBalancerIDs))
-	copy(tmpIDs, ppis.LoadBalancerIDs)
+	return GetPoolItemKey(ppis.ItemName, ppis.LoadBalancerIDs)
+}
+
+// GetPoolItemKey get port pool item key
+func GetPoolItemKey(itemName string, loadBalancerIDs []string) string {
+	tmpIDs := make([]string, len(loadBalancerIDs))
+	copy(tmpIDs, loadBalancerIDs)
 	sort.Strings(tmpIDs)
-	return strings.Join(tmpIDs, ",")
+	return itemName + "-" + strings.Join(tmpIDs, ",")
 }
 
 // PortPoolStatus defines the observed state of PortPool


### PR DESCRIPTION
bcs-ingress-controller 支持 lb 复用，创建和更新 `portpool` 时会由 webhook 检测端口冲突。