### PR TITLE
Performance: watch support large cluster

### DIFF
--- a/bcs-services/bcs-k8s-watch/app/k8s/resources/default.go
+++ b/bcs-services/bcs-k8s-watch/app/k8s/resources/default.go
@@ -223,6 +223,7 @@ func initK8sWatcherConfigList(restConfig *rest.Config, filter map[string]map[str
 	apiResourceLists, err := discoveryClient.ServerPreferredResources()
 	if err != nil {
 		glog.Warnf("error getting apiResourceLists: %s", err.Error())
+		return nil, err
 	}
 
 	for _, apiResourceList := range apiResourceLists {

--- a/bcs-services/bcs-k8s-watch/app/output/handler.go
+++ b/bcs-services/bcs-k8s-watch/app/output/handler.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	// defaultHandlerQueueSize is default queue size of Handler.
-	defaultHandlerQueueSize = 1024
+	defaultHandlerQueueSize = 102400
 
 	// defaultHandleInterval is default interval of handle.
 	defaultHandleInterval = 500 * time.Millisecond

--- a/bcs-services/bcs-k8s-watch/app/output/http/client.go
+++ b/bcs-services/bcs-k8s-watch/app/output/http/client.go
@@ -73,7 +73,7 @@ const (
 	HandlerEventName = "events"
 
 	// request timeout
-	StorageRequestTimeoutSeconds = 2
+	StorageRequestTimeoutSeconds = 5
 
 	// bcsstorage/v1/k8s/watch/clusters/{clusterId}/namespaces/{namespace}/{resourceType}/{resourceName}
 	NamespaceScopeWatchURLFmt = "%s/bcsstorage/v1/k8s/watch/clusters/%s/namespaces/%s/%s/%s"

--- a/bcs-services/bcs-k8s-watch/app/output/writer.go
+++ b/bcs-services/bcs-k8s-watch/app/output/writer.go
@@ -58,6 +58,10 @@ const (
 	Pod = "Pod"
 	// PodPrefix queue key prefix
 	PodPrefix = "Pod_"
+	// Event event resource
+	Event = "Event"
+	// EventPrefix queue key prefix
+	EventPrefix = "Event_"
 )
 
 var (
@@ -144,6 +148,13 @@ func (w *Writer) initWatcherResourceDistributeQueue(clusterID string, resource s
 				w.Handlers[handlerChanKey] = NewHandler(clusterID, handlerChanKey, action)
 			}
 		}
+	case Event:
+		// 4 times of podChanQueueNum for event
+		glog.Infof("resource %s create %d handlerQueue", Event, 4*w.resourceQueueNum.podChanQueueNum)
+		for i := 0; i < 4*w.resourceQueueNum.podChanQueueNum; i++ {
+			handlerChanKey := EventPrefix + strconv.Itoa(i)
+			w.Handlers[handlerChanKey] = NewHandler(clusterID, handlerChanKey, action)
+		}
 	default:
 	}
 }
@@ -194,7 +205,7 @@ func (w *Writer) distributeNormal() {
 				glog.V(3).Infof("write queue receive task, current queue(%d/%d)", len(w.queue), cap(w.queue))
 			}
 
-			handlerKey := w.getHandlerKeyBySyncData(data)
+			handlerKey := w.GetHandlerKeyBySyncData(data)
 			if handler, ok := w.Handlers[handlerKey]; ok {
 				handler.HandleWithTimeout(data, defaultQueueTimeout)
 			} else {
@@ -208,7 +219,8 @@ func (w *Writer) distributeNormal() {
 	}
 }
 
-func (w *Writer) getHandlerKeyBySyncData(data *action.SyncData) string {
+// GetHandlerKeyBySyncData returns the handler key by sync data
+func (w *Writer) GetHandlerKeyBySyncData(data *action.SyncData) string {
 	if w == nil || data == nil {
 		return ""
 	}
@@ -224,6 +236,15 @@ func (w *Writer) getHandlerKeyBySyncData(data *action.SyncData) string {
 				handlerKey = PodPrefix + strconv.Itoa(index)
 			}
 			glog.V(5).Infof("Pod resource[%s], handlerKey[%d: %s]", resourceName, index, handlerKey)
+		}
+	case Event:
+		resourceName := w.getResourceName(data)
+		if len(resourceName) > 0 {
+			index := getHashId(resourceName, 4*w.resourceQueueNum.podChanQueueNum)
+			if index >= 0 {
+				handlerKey = EventPrefix + strconv.Itoa(index)
+			}
+			glog.V(5).Infof("Event resource[%s], handlerKey[%d: %s]", resourceName, index, handlerKey)
 		}
 	default:
 	}

--- a/bcs-services/bcs-k8s-watch/go.mod
+++ b/bcs-services/bcs-k8s-watch/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/Tencent/bk-bcs/bcs-common v0.0.0-00010101000000-000000000000
 	github.com/Tencent/bk-bcs/bcs-k8s/kubebkbcs v0.0.0-00010101000000-000000000000
 	github.com/Tencent/bk-bcs/bcs-mesos/kubebkbcsv2 v0.0.0-00010101000000-000000000000
+	github.com/cch123/gogctuner v0.0.0-20220122185012-72c5314ae0b1
 	github.com/emicklei/go-restful v2.15.0+incompatible
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
@@ -39,6 +40,8 @@ require (
 	github.com/satori/go.uuid v1.2.0
 	github.com/sheerun/queue v1.0.1
 	github.com/spf13/pflag v1.0.5
+	github.com/tklauser/go-sysconf v0.3.10 // indirect
+	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	golang.org/x/net v0.0.0-20201224014010-6772e930b67b
 	golang.org/x/oauth2 v0.0.0-20210113205817-d3ed898aa8a3 // indirect
 	k8s.io/api v0.18.6

--- a/bcs-services/bcs-k8s-watch/main.go
+++ b/bcs-services/bcs-k8s-watch/main.go
@@ -20,11 +20,23 @@ import (
 	"github.com/Tencent/bk-bcs/bcs-common/common/conf"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-k8s-watch/app"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-k8s-watch/app/options"
+	"github.com/cch123/gogctuner"
 )
 
-func main() {
-	runtime.GOMAXPROCS(runtime.NumCPU())
+const (
+	// InCgroup default running in container
+	InCgroup = true
+	// DefaultGCTarget default GC target set to 70 percent
+	DefaultGCTarget = 70.0
+)
 
+func init() {
+	runtime.GOMAXPROCS(runtime.NumCPU())
+	// tune gc
+	go gogctuner.NewTuner(InCgroup, DefaultGCTarget)
+}
+
+func main() {
 	watchConfig := options.NewWatchOptions()
 	conf.Parse(watchConfig)
 


### PR DESCRIPTION
1. increase defaultHandlerQueueSize.
2. directly move data from watchers to handlers.
3. hash event resource to different handlers.