### PR TITLE
fix: 修复 Mesos Scheduler 不能正常创建 AgentSetting 问题

### DIFF
--- a/bcs-runtime/bcs-mesos/bcs-scheduler/src/manager/sched/offer/offerpool.go
+++ b/bcs-runtime/bcs-mesos/bcs-scheduler/src/manager/sched/offer/offerpool.go
@@ -588,7 +588,7 @@ func (p *offerPool) setInnerOffersAttributes(offers []*mesos.Offer) {
 		}
 
 		setting, err := p.scheduler.FetchAgentSetting(ip)
-		if err != nil {
+		if err != nil && !errors.Is(err, store.ErrNoFound) {
 			blog.Errorf("FetchAgentSetting ip %s error %s", ip, err.Error())
 			continue
 		}
@@ -1050,7 +1050,7 @@ func (p *offerPool) validateDisableSlave(offer *mesos.Offer) bool {
 	}
 
 	setting, err := p.scheduler.FetchAgentSetting(ip)
-	if err != nil {
+	if err != nil && !errors.Is(err, store.ErrNoFound) {
 		blog.Errorf("FetchAgentSetting ip %s error %s", ip, err.Error())
 		return true
 	}

--- a/bcs-runtime/bcs-mesos/bcs-scheduler/src/manager/sched/scheduler/scheduler.go
+++ b/bcs-runtime/bcs-mesos/bcs-scheduler/src/manager/sched/scheduler/scheduler.go
@@ -930,7 +930,7 @@ func (s *Scheduler) syncAgentsettingPods() error {
 		}
 
 		setting, err := s.store.FetchAgentSetting(nodeIP)
-		if err != nil {
+		if err != nil && !errors.Is(err, store.ErrNoFound) {
 			blog.Errorf("FetchAgentSetting %s failed: %s", nodeIP, err.Error())
 			return err
 		}


### PR DESCRIPTION
Mesos Scheduler 由于缺少一个判断错误类型的判断，导致下述 Save AgentSetting 的逻辑无法执行。
