### PR TITLE
bcs-general-pod-autoscaler support to set workers

### DIFF
--- a/bcs-runtime/bcs-k8s/bcs-component/bcs-general-pod-autoscaler/cmd/gpa/app/default.go
+++ b/bcs-runtime/bcs-k8s/bcs-component/bcs-general-pod-autoscaler/cmd/gpa/app/default.go
@@ -43,7 +43,10 @@ func RecommendDefaultGPAControllerConfig(obj *v1alpha1.GPAControllerConfiguratio
 	if obj.GeneralPodAutoscalerDownscaleForbiddenWindow == zero {
 		obj.GeneralPodAutoscalerDownscaleForbiddenWindow = metav1.Duration{Duration: 5 * time.Minute}
 	}
-	if obj.GeneralPodAutoscalerTolerance == 0 {
+	if obj.GeneralPodAutoscalerTolerance <= 0 {
 		obj.GeneralPodAutoscalerTolerance = 0.1
+	}
+	if obj.GeneralPodAutoscalerWorkers < 1 {
+		obj.GeneralPodAutoscalerWorkers = 1
 	}
 }

--- a/bcs-runtime/bcs-k8s/bcs-component/bcs-general-pod-autoscaler/cmd/gpa/app/options.go
+++ b/bcs-runtime/bcs-k8s/bcs-component/bcs-general-pod-autoscaler/cmd/gpa/app/options.go
@@ -100,6 +100,10 @@ func (o *RunOptions) addGPAFlags() {
 		"general-pod-autoscaler-initial-readiness-delay",
 		o.GeneralPodAutoscalerInitialReadinessDelay.Duration,
 		"The period after pod start during which readiness changes will be treated as initial readiness.")
+	pflag.IntVar(&o.GeneralPodAutoscalerWorkers,
+		"general-pod-autoscaler-workers",
+		o.GeneralPodAutoscalerWorkers,
+		"The number for parallel process worker.")
 }
 
 // NewConfig new config

--- a/bcs-runtime/bcs-k8s/bcs-component/bcs-general-pod-autoscaler/cmd/gpa/main.go
+++ b/bcs-runtime/bcs-k8s/bcs-component/bcs-general-pod-autoscaler/cmd/gpa/main.go
@@ -134,6 +134,7 @@ func main() {
 		runConfig.GeneralPodAutoscalerTolerance,
 		runConfig.GeneralPodAutoscalerCPUInitializationPeriod.Duration,
 		runConfig.GeneralPodAutoscalerInitialReadinessDelay.Duration,
+		runConfig.GeneralPodAutoscalerWorkers,
 	)
 	coreFactory.Start(stop)
 	scalerFactory.Start(stop)

--- a/bcs-runtime/bcs-k8s/bcs-component/bcs-general-pod-autoscaler/pkg/apis/config/v1alpha1/types.go
+++ b/bcs-runtime/bcs-k8s/bcs-component/bcs-general-pod-autoscaler/pkg/apis/config/v1alpha1/types.go
@@ -46,4 +46,7 @@ type GPAControllerConfiguration struct {
 	// GPA will disregard CPU samples from unready pods that had last readiness change during that
 	// period.
 	GeneralPodAutoscalerInitialReadinessDelay metav1.Duration
+	// GeneralPodAutoscalerWorkers is the goroutine number of GPA controller to parallel process worker
+	// default value is 1
+	GeneralPodAutoscalerWorkers int
 }

--- a/bcs-runtime/bcs-k8s/bcs-component/bcs-general-pod-autoscaler/pkg/scaler/general_test.go
+++ b/bcs-runtime/bcs-k8s/bcs-component/bcs-general-pod-autoscaler/pkg/scaler/general_test.go
@@ -692,6 +692,7 @@ func (tc *testCase) setupController(t *testing.T) (*GeneralController, informers
 		defaultTestingTolerance,
 		defaultTestingCPUInitializationPeriod,
 		defaultTestingDelayOfInitialReadinessStatus,
+		1,
 	)
 	gpaController.gpaListerSynced = alwaysReady
 	if tc.recommendations != nil {


### PR DESCRIPTION
Support to set workers, bcs-general-pod-autoscaler can be processed in parallel for workload autoscaling request.
args like this:
```
- args:
        - --election-resource-lock=endpoints
        - --tlscert=/root/cert.pem
        - --tlskey=/root/key.pem
        - --general-pod-autoscaler-workers=4
        - --v=4
        - --port=443
```