### PR TITLE
bcs-cluster-resources添加 tracing

### DIFF
--- a/bcs-services/cluster-resources/cmd/cr.go
+++ b/bcs-services/cluster-resources/cmd/cr.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/config"
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/i18n"
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/logging"
+	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/tracing/jaeger"
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/util/errorx"
 	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/version"
 )
@@ -71,6 +72,15 @@ func Start() {
 	// 初始化 I18N 相关配置
 	if err = i18n.InitMsgMap(); err != nil {
 		panic(errorx.New(errcode.General, "init i18n message map failed: %v", err))
+	}
+
+	//初始化 Tracer
+	closer, err := jaeger.InitTracingInstance(&crConf.Tracing)
+	if err != nil {
+		panic(errorx.New(errcode.General, "initTracingInstance failed: %v", err))
+	}
+	if closer != nil {
+		defer closer.Close()
 	}
 
 	crSvc := newClusterResourcesService(crConf)

--- a/bcs-services/cluster-resources/cmd/init.go
+++ b/bcs-services/cluster-resources/cmd/init.go
@@ -32,6 +32,7 @@ import (
 	microGrpc "github.com/go-micro/plugins/v4/server/grpc"
 	"github.com/gorilla/mux"
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/opentracing/opentracing-go"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/tmc/grpc-websocket-proxy/wsproxy"
 	"go-micro.dev/v4"
@@ -154,6 +155,10 @@ func (crSvc *clusterResourcesService) initMicro() error {
 		server.WrapHandler(
 			// 格式化返回结果
 			wrapper.NewResponseFormatWrapper(),
+		),
+		server.WrapHandler(
+			//	链路追踪
+			wrapper.NewHandlerWrapper(opentracing.GlobalTracer()),
 		),
 		server.WrapHandler(
 			// 记录 API 访问流水日志

--- a/bcs-services/cluster-resources/etc/conf.yaml
+++ b/bcs-services/cluster-resources/etc/conf.yaml
@@ -114,3 +114,17 @@ crGlobal:
   sharedCluster:
     enabledCObjKinds: []
     enabledCRDs: []
+
+# Tracing 相关配置
+tracing:
+  tracingSwitch: "on"
+  tracingType: "jaeger"
+  serviceName: "bcs-cluster-resources"
+  rPCMetrics: true
+  reportMetrics: true
+  reportLog: true
+  agentFromEnv: false
+  AgentHostPort: "127.0.0.1:6831"
+  sampleType: "const"
+  sampleParameter: 1
+  sampleFromEnv: false

--- a/bcs-services/cluster-resources/pkg/config/config.go
+++ b/bcs-services/cluster-resources/pkg/config/config.go
@@ -96,6 +96,7 @@ type ClusterResourcesConf struct {
 	Log     LogConf     `yaml:"log"`
 	Redis   RedisConf   `yaml:"redis"`
 	Global  GlobalConf  `yaml:"crGlobal"`
+	Tracing TracingConf `yaml:"tracing"`
 }
 
 func (c *ClusterResourcesConf) initServerAddress() error {
@@ -282,4 +283,19 @@ type IAMConf struct {
 type SharedClusterConf struct {
 	EnabledCObjKinds []string `yaml:"enabledCObjKinds" usage:"共享集群中支持的自定义对象 Kind"`
 	EnabledCRDs      []string `yaml:"enabledCRDs" usage:"共享集群中支持的 CRD"` // nolint:tagliatelle
+}
+
+type TracingConf struct {
+	TracingSwitch     string  `yaml:"tracingSwitch" usage:"tracing switch"`
+	TracingType       string  `yaml:"tracingType" usage:"tracing type(default jaeger)"`
+	ServiceName       string  `yaml:"serviceName" usage:"tracing serviceName"`
+	RPCMetrics        bool    `yaml:"rPCMetrics"`
+	ReportMetrics     bool    `json:"reportMetrics"`
+	ReportLog         bool    `json:"reportLog"`
+	AgentFromEnv      bool    `json:"agentFromEnv"`
+	AgentHostPort     string  `json:"agentHostPort"`
+	SampleType        string  `json:"sampleType"`
+	SampleParameter   float64 `json:"sampleParameter"`
+	SampleFromEnv     bool    `json:"sampleFromEnv"`
+	SamplingServerURL string  `json:"samplingServerURL"`
 }

--- a/bcs-services/cluster-resources/pkg/tracing/jaeger/init.go
+++ b/bcs-services/cluster-resources/pkg/tracing/jaeger/init.go
@@ -1,0 +1,73 @@
+/*
+ * Tencent is pleased to support the open source community by making Blueking Container Service available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package jaeger
+
+import (
+	"io"
+
+	"github.com/Tencent/bk-bcs/bcs-common/common/blog"
+	"github.com/Tencent/bk-bcs/bcs-common/pkg/tracing"
+	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/config"
+)
+
+func InitTracingInstance(op *config.TracingConf) (io.Closer, error) {
+	opts := []tracing.Option{}
+	if op.TracingSwitch != "" {
+		opts = append(opts, tracing.TracerSwitch(op.TracingSwitch))
+	}
+	if op.TracingType != "" {
+		opts = append(opts, tracing.TracerType(tracing.TraceType(op.TracingType)))
+	}
+	if op.RPCMetrics {
+		opts = append(opts, tracing.RPCMetrics(op.RPCMetrics))
+	}
+	if op.ReportMetrics {
+		opts = append(opts, tracing.ReportMetrics(op.ReportMetrics))
+	}
+	// init reporter
+	if op.ReportLog {
+		opts = append(opts, tracing.ReportLog(op.ReportLog))
+	}
+	if op.AgentFromEnv {
+		opts = append(opts, tracing.AgentFromEnv(op.AgentFromEnv))
+	}
+	if op.AgentHostPort != "" {
+		opts = append(opts, tracing.AgentHostPort(op.AgentHostPort))
+	}
+	// init sampler
+	if op.SampleType != "" {
+		opts = append(opts, tracing.SampleType(op.SampleType),
+			tracing.SampleParameter(op.SampleParameter))
+	}
+	if op.SampleFromEnv {
+		opts = append(opts, tracing.SampleFromEnv(op.SampleFromEnv))
+	}
+	if op.SamplingServerURL != "" {
+		opts = append(opts, tracing.SamplingServerURL(op.SamplingServerURL))
+	}
+
+	tracer, err := tracing.NewInitTracing(op.ServiceName, opts...)
+	if err != nil {
+		blog.Errorf("failed to init tracing factory, err: %v", err)
+		return nil, err
+	}
+	closer, err := tracer.Init()
+	if err != nil {
+		blog.Errorf("failed to init tracing system, err: %v", err)
+		return nil, err
+	}
+
+	blog.Infof("bcs-tracing switch: %s", op.TracingSwitch)
+	return closer, nil
+}

--- a/bcs-services/cluster-resources/pkg/wrapper/jaeger.go
+++ b/bcs-services/cluster-resources/pkg/wrapper/jaeger.go
@@ -1,0 +1,101 @@
+/*
+ * Tencent is pleased to support the open source community by making Blueking Container Service available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wrapper
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
+	opentracinglog "github.com/opentracing/opentracing-go/log"
+	"go-micro.dev/v4/server"
+	"google.golang.org/grpc/grpclog"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/Tencent/bk-bcs/bcs-services/cluster-resources/pkg/common/ctxkey"
+)
+
+type MDReaderWriter struct {
+	metadata.MD
+}
+
+func (c MDReaderWriter) ForeachKey(handler func(key, val string) error) error {
+	for k, vs := range c.MD {
+		for _, v := range vs {
+			if err := handler(k, v); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (c MDReaderWriter) Set(key, val string) {
+	key = strings.ToLower(key)
+	c.MD[key] = append(c.MD[key], val)
+}
+
+func NewHandlerWrapper(tracer opentracing.Tracer) server.HandlerWrapper {
+	return func(fn server.HandlerFunc) server.HandlerFunc {
+		return func(ctx context.Context, req server.Request, rsp interface{}) (err error) {
+			// 开始时间
+			startTime := time.Now().UnixNano() / 1000000
+			md, ok := metadata.FromIncomingContext(ctx)
+			if !ok {
+				md = metadata.New(nil)
+			}
+
+			spanContext, err := tracer.Extract(opentracing.TextMap, MDReaderWriter{MD: md})
+			if err != nil && err != opentracing.ErrSpanContextNotFound {
+				grpclog.Errorf("extract from metadata err: %v", err)
+			}
+			name := fmt.Sprintf("%s.%s", req.Service(), req.Endpoint())
+			span := tracer.StartSpan(
+				name,
+				opentracing.ChildOf(spanContext),
+				opentracing.Tag{Key: string(ext.Component), Value: "gRPC"},
+				ext.SpanKindRPCServer,
+			)
+
+			defer span.Finish()
+
+			ext.HTTPMethod.Set(span, req.Method())
+			ext.HTTPUrl.Set(span, req.Endpoint())
+
+			ctx = opentracing.ContextWithSpan(ctx, span)
+
+			ctx = context.WithValue(ctx, "Tracer", tracer)
+			ctx = context.WithValue(ctx, "ParentSpanContext", span.Context())
+
+			err = fn(ctx, req, rsp)
+			// 结束时间
+			endTime := time.Now().UnixNano() / 1000000
+			costTime := fmt.Sprintf("%vms", endTime-startTime)
+			// 设置额外标签
+			span.SetTag("request", req.Body())
+			span.SetTag("reply", rsp)
+			span.SetTag("cost_time", costTime)
+			span.SetTag("parent-id", ctx.Value(ctxkey.RequestIDKey))
+			if err != nil {
+				span.LogFields(opentracinglog.String("error", err.Error()))
+				span.SetTag("error", true)
+			}
+
+			return err
+		}
+	}
+}


### PR DESCRIPTION
- 添加 tracing 支持
- 对第三方调用，如cluster-manager, project-manager等，记录请求，返回内容(注意返回大小，超过2k截断)，耗时等，注意有grpc请求
- issues: https://github.com/Tencent/bk-bcs/issues/1941