### PR TITLE
fix: 修复Azure bug

### DIFF
--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/cluster.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/cluster.go
@@ -176,7 +176,7 @@ func (c *Cluster) GetCluster(cloudID string, opt *cloudprovider.GetClusterOption
 		opt.Cluster.ClusterAdvanceSettings.NetworkType = common.AzureCniOverlay
 	}
 
-	if opt.Cluster.NetworkType == "" {
+	if opt.Cluster.ClusterAdvanceSettings.NetworkType == common.AzureCniOverlay {
 		opt.Cluster.NetworkType = common.ClusterOverlayNetwork
 	}
 

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/nodegroup.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/nodegroup.go
@@ -127,6 +127,12 @@ func (ng *NodeGroup) UpdateNodeGroup(group *proto.NodeGroup, opt *cloudprovider.
 		group.NodeTemplate.Module.ScaleOutModuleName = cloudprovider.GetModuleName(bkBizID, bkModuleID)
 	}
 
+	err = cloudprovider.GetStorageModel().UpdateNodeGroup(context.Background(), group)
+	if err != nil {
+		blog.Errorf("BuildUpdateNodeGroupTask failed: %v", err)
+		return nil, err
+	}
+
 	return task, nil
 }
 

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/tasks/importCluster.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/tasks/importCluster.go
@@ -241,6 +241,11 @@ func importNodeResourceGroup(info *cloudprovider.CloudDependBasicInfo) error {
 	for _, pool := range managedCluster.Properties.AgentPoolProfiles {
 		if *pool.Mode == common.CloudClusterNodeGroupTypeSystem {
 			sysPoolName = *pool.Name
+
+			// 获取节点池maxpods
+			if pool.MaxPods != nil && *pool.MaxPods > 0 {
+				cluster.NetworkSettings.MaxNodePodNum = uint32(*pool.MaxPods)
+			}
 		}
 	}
 	set, err := client.MatchNodeGroup(ctx, cluster.ExtraInfo[common.NodeResourceGroup], sysPoolName)

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/tasks/updateNodeGroup.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/tasks/updateNodeGroup.go
@@ -161,10 +161,6 @@ func checkPoolState(pool *armcontainerservice.AgentPool) error {
 }
 
 func updateVMSSProperties(client api.AksService, group *proto.NodeGroup) error {
-	if group.LaunchTemplate == nil || len(group.LaunchTemplate.UserData) == 0 {
-		return nil
-	}
-
 	asg := group.AutoScaling
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/vpc.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/vpc.go
@@ -107,8 +107,12 @@ func (vm *VPCManager) ListSubnets(vpcID, zone string, opt *cloudprovider.ListNet
 	result := make([]*proto.Subnet, 0)
 	for _, v := range subnets {
 		var cidr string
-		if v.Properties != nil && v.Properties.AddressPrefix != nil {
-			cidr = *v.Properties.AddressPrefix
+		if v.Properties != nil {
+			if v.Properties.AddressPrefix != nil && *v.Properties.AddressPrefix != "" {
+				cidr = *v.Properties.AddressPrefix
+			} else if len(v.Properties.AddressPrefixes) > 0 {
+				cidr = *v.Properties.AddressPrefixes[0]
+			}
 		}
 
 		result = append(result, &proto.Subnet{


### PR DESCRIPTION
1. 修复导入Azure集群没有设置集群的节点最大pod值的问题
2. 修复Azure获取集群子网列表返回的剩余IP数错误
3. 修复azure集群信息中，网络插件显示的网络类型错误的问题
4. 修复更新节点池更改为异步后，更新到Azure时获取到了旧的节点数据导致更新节点池数据失败的问题