### PR TITLE
fix: 完善导入Azure集群数据同步的问题并修复部分bug

### DIFF
--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/business/cluster.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/business/cluster.go
@@ -17,11 +17,10 @@ import (
 	"context"
 	"fmt"
 
+	proto "github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/api/clustermanager"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/cloudprovider"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/api"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/common"
-
-	proto "github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/api/clustermanager"
 )
 
 // SyncClusterInfo sync cluster info

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/business/cluster.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/business/cluster.go
@@ -1,0 +1,85 @@
+/*
+ * Tencent is pleased to support the open source community by making Blueking Container Service available.
+ * Copyright (C) 2019 THL A29 Limited, a Tencent company. All rights reserved.
+ * Licensed under the MIT License (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * http://opensource.org/licenses/MIT
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package business xxx
+package business
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/cloudprovider"
+	"github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/api"
+	"github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/common"
+
+	proto "github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/api/clustermanager"
+)
+
+// SyncClusterInfo sync cluster info
+func SyncClusterInfo(opt *cloudprovider.GetClusterOption) error {
+	if opt.Cluster.ClusterAdvanceSettings == nil {
+		opt.Cluster.ClusterAdvanceSettings = &proto.ClusterAdvanceSetting{
+			ClusterConnectSetting: &proto.ClusterConnectSetting{
+				Internet: &proto.InternetAccessible{},
+			},
+		}
+	} else if opt.Cluster.ClusterAdvanceSettings.ClusterConnectSetting == nil {
+		opt.Cluster.ClusterAdvanceSettings.ClusterConnectSetting = &proto.ClusterConnectSetting{
+			Internet: &proto.InternetAccessible{},
+		}
+	} else if opt.Cluster.ClusterAdvanceSettings.ClusterConnectSetting.Internet == nil {
+		opt.Cluster.ClusterAdvanceSettings.ClusterConnectSetting.Internet = &proto.InternetAccessible{}
+	}
+
+	client, err := api.NewAksServiceImplWithCommonOption(&opt.CommonOption)
+	if err != nil {
+		return fmt.Errorf("init AksService failed, %v", err)
+	}
+
+	cloudCluster, err := client.GetClusterWithName(context.Background(),
+		cloudprovider.GetClusterResourceGroup(opt.Cluster), opt.Cluster.SystemID)
+	if err != nil {
+		return err
+	}
+
+	// 同步集群是否为公网
+	profile := cloudCluster.Properties.APIServerAccessProfile
+	if profile == nil || profile.EnablePrivateCluster == nil || !*profile.EnablePrivateCluster {
+		opt.Cluster.ClusterAdvanceSettings.ClusterConnectSetting.IsExtranet = true
+	} else {
+		opt.Cluster.ClusterAdvanceSettings.ClusterConnectSetting.IsExtranet = false
+	}
+
+	// 同步集群白名单
+	internet := opt.Cluster.ClusterAdvanceSettings.ClusterConnectSetting.Internet
+	internet.PublicAccessCidrs = []string{}
+	if profile != nil && len(profile.AuthorizedIPRanges) > 0 {
+		for _, ipRange := range profile.AuthorizedIPRanges {
+			internet.PublicAccessCidrs = append(internet.PublicAccessCidrs, *ipRange)
+		}
+	}
+
+	// 同步集群网络插件
+	networkProfile := cloudCluster.Properties.NetworkProfile
+	if networkProfile != nil {
+		if networkProfile.NetworkPluginMode != nil &&
+			*networkProfile.NetworkPluginMode == common.ClusterOverlayNetwork {
+			opt.Cluster.ClusterAdvanceSettings.NetworkType = common.AzureCniOverlay
+			opt.Cluster.NetworkType = common.ClusterOverlayNetwork
+		} else {
+			opt.Cluster.ClusterAdvanceSettings.NetworkType = common.AzureCniNodeSubnet
+			opt.Cluster.NetworkType = common.ClusterUnderlayNetwork
+		}
+	}
+
+	return nil
+}

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/cloud.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/cloud.go
@@ -81,7 +81,7 @@ func (c *CloudInfoManager) SyncClusterCloudInfo(cls *proto.Cluster,
 	// cluster cloud basic setting
 	clusterBasicSettingByAzure(cls, cluster, opt)
 	// cluster cloud advance setting
-	clusterAdvanceSettingByAzure(cls, cluster, opt)
+	clusterAdvanceSettingByAzure(cls, cluster)
 	// cluster cloud network setting
 	err = clusterNetworkSettingByAzure(cls, cluster)
 	if err != nil {
@@ -131,8 +131,7 @@ func clusterBasicSettingByAzure(cls *proto.Cluster, cluster *armcontainerservice
 }
 
 // clusterAdvanceSettingByAzure 同步集群高级设置
-func clusterAdvanceSettingByAzure(cls *proto.Cluster, cluster *armcontainerservice.ManagedCluster,
-	opt *cloudprovider.SyncClusterCloudInfoOption) {
+func clusterAdvanceSettingByAzure(cls *proto.Cluster, cluster *armcontainerservice.ManagedCluster) {
 	if cls.ClusterAdvanceSettings == nil {
 		cls.ClusterAdvanceSettings = &proto.ClusterAdvanceSetting{
 			ClusterConnectSetting: &proto.ClusterConnectSetting{

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/cloud.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/cloud.go
@@ -24,6 +24,7 @@ import (
 	proto "github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/api/clustermanager"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/cloudprovider"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/api"
+	"github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/common"
 )
 
 var cloudInfoMgr sync.Once
@@ -79,6 +80,8 @@ func (c *CloudInfoManager) SyncClusterCloudInfo(cls *proto.Cluster,
 	cls.SystemID = *cluster.Name
 	// cluster cloud basic setting
 	clusterBasicSettingByAzure(cls, cluster, opt)
+	// cluster cloud advance setting
+	clusterAdvanceSettingByAzure(cls, cluster, opt)
 	// cluster cloud network setting
 	err = clusterNetworkSettingByAzure(cls, cluster)
 	if err != nil {
@@ -124,6 +127,51 @@ func clusterBasicSettingByAzure(cls *proto.Cluster, cluster *armcontainerservice
 		Version:     *cluster.Properties.CurrentKubernetesVersion,
 		VersionName: *cluster.Properties.CurrentKubernetesVersion,
 		Area:        opt.Area,
+	}
+}
+
+// clusterAdvanceSettingByAzure 同步集群高级设置
+func clusterAdvanceSettingByAzure(cls *proto.Cluster, cluster *armcontainerservice.ManagedCluster,
+	opt *cloudprovider.SyncClusterCloudInfoOption) {
+	if cls.ClusterAdvanceSettings == nil {
+		cls.ClusterAdvanceSettings = &proto.ClusterAdvanceSetting{
+			ClusterConnectSetting: &proto.ClusterConnectSetting{
+				Internet: &proto.InternetAccessible{},
+			},
+		}
+	}
+
+	profile := cluster.Properties.APIServerAccessProfile
+	if profile != nil {
+		internet := cls.ClusterAdvanceSettings.ClusterConnectSetting.Internet
+		// 同步集群白名单
+		if len(profile.AuthorizedIPRanges) > 0 {
+			for _, cidr := range profile.AuthorizedIPRanges {
+				internet.PublicAccessCidrs = append(internet.PublicAccessCidrs, *cidr)
+			}
+		}
+
+		// 同步集群是否为公网集群
+		if profile.EnablePrivateCluster == nil {
+			cls.ClusterAdvanceSettings.ClusterConnectSetting.IsExtranet = true
+		} else if *profile.EnablePrivateCluster {
+			cls.ClusterAdvanceSettings.ClusterConnectSetting.IsExtranet = true
+		}
+	} else {
+		cls.ClusterAdvanceSettings.ClusterConnectSetting.IsExtranet = true
+	}
+
+	// 同步集群网络插件
+	networkProfile := cluster.Properties.NetworkProfile
+	if networkProfile != nil {
+		if networkProfile.NetworkPluginMode != nil &&
+			*networkProfile.NetworkPluginMode == common.ClusterOverlayNetwork {
+			cls.ClusterAdvanceSettings.NetworkType = common.AzureCniOverlay
+			cls.NetworkType = common.ClusterOverlayNetwork
+		} else {
+			cls.ClusterAdvanceSettings.NetworkType = common.AzureCniNodeSubnet
+			cls.NetworkType = common.ClusterUnderlayNetwork
+		}
 	}
 }
 

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/cloud.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/cloud.go
@@ -132,12 +132,10 @@ func clusterBasicSettingByAzure(cls *proto.Cluster, cluster *armcontainerservice
 
 // clusterAdvanceSettingByAzure 同步集群高级设置
 func clusterAdvanceSettingByAzure(cls *proto.Cluster, cluster *armcontainerservice.ManagedCluster) {
-	if cls.ClusterAdvanceSettings == nil {
-		cls.ClusterAdvanceSettings = &proto.ClusterAdvanceSetting{
-			ClusterConnectSetting: &proto.ClusterConnectSetting{
-				Internet: &proto.InternetAccessible{},
-			},
-		}
+	cls.ClusterAdvanceSettings = &proto.ClusterAdvanceSetting{
+		ClusterConnectSetting: &proto.ClusterConnectSetting{
+			Internet: &proto.InternetAccessible{},
+		},
 	}
 
 	profile := cluster.Properties.APIServerAccessProfile

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/cluster.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/cluster.go
@@ -151,16 +151,17 @@ func (c *Cluster) DeleteCluster(cls *proto.Cluster, opt *cloudprovider.DeleteClu
 
 // GetCluster get kubernetes cluster detail information according cloudprovider
 func (c *Cluster) GetCluster(cloudID string, opt *cloudprovider.GetClusterOption) (*proto.Cluster, error) {
+	err := business.SyncClusterInfo(opt)
+	if err != nil {
+		return nil, err
+	}
+
 	runtimeInfo, err := business.GetRuntimeInfo(opt.Cluster.ClusterID)
 	if err != nil {
 		return nil, err
 	}
 
-	if opt.Cluster.ClusterAdvanceSettings == nil {
-		opt.Cluster.ClusterAdvanceSettings = &proto.ClusterAdvanceSetting{}
-	}
 	if v, ok := runtimeInfo[common.ContainerdRuntime]; ok {
-
 		opt.Cluster.ClusterAdvanceSettings.ContainerRuntime = common.ContainerdRuntime
 		if len(v) > 0 {
 			opt.Cluster.ClusterAdvanceSettings.RuntimeVersion = v[0]

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/taskmgr.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/taskmgr.go
@@ -14,6 +14,7 @@ package azure
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -914,8 +915,14 @@ func (t *Task) BuildUpdateNodeGroupTask(group *proto.NodeGroup, opt *cloudprovid
 	taskName := fmt.Sprintf(updateNodeGroupTaskTemplate, group.ClusterID, group.NodeGroupID)
 	task.CommonParams[cloudprovider.TaskNameKey.String()] = taskName
 
+	// 异步任务需要序列化传递避免获取到旧的nodegroup信息
+	NodeGroupInfo, err := json.Marshal(group)
+	if err != nil {
+		return nil, fmt.Errorf("BuildUpdateNodeGroupTask nodegroup info json marshal failed: %v", err)
+	}
+
 	// setting all steps details
-	updateNodeGroupTask := &UpdateNodeGroupTaskOption{NodeGroup: group}
+	updateNodeGroupTask := &UpdateNodeGroupTaskOption{NodeGroup: group, NodeGroupInfo: string(NodeGroupInfo)}
 
 	// step0: update nodegroup
 	updateNodeGroupTask.BuildUpdateNodeGroupStep(task)

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/tasks/createNodeGroup.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/tasks/createNodeGroup.go
@@ -266,7 +266,13 @@ func updateClusterAuthorizedIPRange(rootCtx context.Context, info *cloudprovider
 			taskID)
 	}
 
-	if cluster.ClusterAdvanceSettings.ClusterConnectSetting == nil {
+	if cluster.ClusterAdvanceSettings == nil {
+		cluster.ClusterAdvanceSettings = &proto.ClusterAdvanceSetting{
+			ClusterConnectSetting: &proto.ClusterConnectSetting{
+				Internet: &proto.InternetAccessible{},
+			},
+		}
+	} else if cluster.ClusterAdvanceSettings.ClusterConnectSetting == nil {
 		cluster.ClusterAdvanceSettings.ClusterConnectSetting = &proto.ClusterConnectSetting{
 			Internet: &proto.InternetAccessible{},
 		}

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/utils.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/utils.go
@@ -387,7 +387,8 @@ func (ud *UpdateDesiredNodesTaskOption) BuildCheckClusterNodeStatusStep(task *pr
 
 // UpdateNodeGroupTaskOption 创建集群构建step子任务
 type UpdateNodeGroupTaskOption struct {
-	NodeGroup *proto.NodeGroup
+	NodeGroup     *proto.NodeGroup
+	NodeGroupInfo string
 }
 
 // BuildUpdateNodeGroupStep 更新节点池
@@ -395,6 +396,7 @@ func (cn *UpdateNodeGroupTaskOption) BuildUpdateNodeGroupStep(task *proto.Task) 
 	updateNodeGroupStep := cloudprovider.InitTaskStep(updateAKSNodeGroupStep)
 	updateNodeGroupStep.Params[cloudprovider.ClusterIDKey.String()] = cn.NodeGroup.ClusterID
 	updateNodeGroupStep.Params[cloudprovider.NodeGroupIDKey.String()] = cn.NodeGroup.NodeGroupID
+	updateNodeGroupStep.Params[cloudprovider.NodeGroupInfoKey.String()] = cn.NodeGroupInfo
 	updateNodeGroupStep.Params[cloudprovider.CloudIDKey.String()] = cn.NodeGroup.Provider
 
 	task.Steps[updateAKSNodeGroupStep.StepMethod] = updateNodeGroupStep

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/vpc.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/azure/vpc.go
@@ -107,8 +107,13 @@ func (vm *VPCManager) ListSubnets(vpcID, zone string, opt *cloudprovider.ListNet
 	result := make([]*proto.Subnet, 0)
 	for _, v := range subnets {
 		var cidr string
-		if v.Properties != nil && v.Properties.AddressPrefix != nil {
-			cidr = *v.Properties.AddressPrefix
+		if v.Properties != nil {
+			// AddressPrefix有可能为空，需要在AddressPrefixes获取
+			if v.Properties.AddressPrefix != nil && *v.Properties.AddressPrefix != "" {
+				cidr = *v.Properties.AddressPrefix
+			} else if len(v.Properties.AddressPrefixes) > 0 {
+				cidr = *v.Properties.AddressPrefixes[0]
+			}
 		}
 
 		result = append(result, &proto.Subnet{

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/common/component.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/common/component.go
@@ -820,10 +820,10 @@ func ensureAutoScalerWithInstaller(ctx context.Context, nodeGroups []*proto.Node
 		// check status
 		ok, errCheck := installer.CheckAppStatus(as.ClusterID, time.Minute*10, false)
 		if errCheck != nil {
-			return fmt.Errorf("check app status failed, err %s", err)
+			return fmt.Errorf("check app status failed, err %s", errCheck)
 		}
 		if !ok {
-			return fmt.Errorf("app install failed, err %s", err)
+			return fmt.Errorf("app install failed")
 		}
 
 		cloudprovider.GetStorageModel().CreateTaskStepLogInfo(context.Background(),

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/constants.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/constants.go
@@ -167,6 +167,8 @@ var (
 	HostClusterIDKey ParamKey = "hostClusterID"
 	// NodeGroupIDKey xxx
 	NodeGroupIDKey ParamKey = "nodeGroupID"
+	// NodeGroupInfoKey xxx
+	NodeGroupInfoKey ParamKey = "nodeGroupInfo"
 	// DeviceRecordIDKey deviceRecord key
 	DeviceRecordIDKey ParamKey = "deviceRecordKey"
 	// ManualKey xxx


### PR DESCRIPTION
修复Azure获取集群子网列表返回的剩余IP数错误
修复azure集群信息中，网络插件显示的网络类型错误的问题
修复更新节点池更改为异步后，更新到Azure时获取到了旧的节点数据导致更新节点池数据失败的问题
导入集群同步白名单和是否为公网的信息
修复更新集群的时候ClusterAdvanceSettings结构体可能为nil的情况
修复Azure集群现存单节点Pod数量上限为空的问题