### PR TITLE
fix: 修复gke的bug

### DIFF
--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/google/api/utils.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/google/api/utils.go
@@ -214,9 +214,6 @@ func GenerateNodePool(input *CreateNodePoolRequest) *container.NodePool {
 		Name:             input.NodePool.Name,
 		InitialNodeCount: input.NodePool.InitialNodeCount,
 		Locations:        input.NodePool.Locations,
-		MaxPodsConstraint: &container.MaxPodsConstraint{
-			MaxPodsPerNode: input.NodePool.MaxPodsConstraint.MaxPodsPerNode,
-		},
 		Autoscaling: &container.NodePoolAutoscaling{
 			Enabled: false,
 		},
@@ -246,6 +243,12 @@ func GenerateNodePool(input *CreateNodePoolRequest) *container.NodePool {
 		nodePool.Management = &container.NodeManagement{
 			AutoRepair:  input.NodePool.Management.AutoRepair,
 			AutoUpgrade: input.NodePool.Management.AutoUpgrade,
+		}
+	}
+
+	if input.NodePool.MaxPodsConstraint.MaxPodsPerNode > 0 {
+		nodePool.MaxPodsConstraint = &container.MaxPodsConstraint{
+			MaxPodsPerNode: input.NodePool.MaxPodsConstraint.MaxPodsPerNode,
 		}
 	}
 

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/google/cloud.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/google/cloud.go
@@ -88,6 +88,11 @@ func (c *CloudInfoManager) SyncClusterCloudInfo(cls *cmproto.Cluster,
 	}
 	cls.KubeConfig = kubeConfig
 
+	// gke集群是否启用autopilot
+	if cluster.Autopilot.Enabled {
+		cls.AutoGenerateMasterNodes = true
+	}
+
 	// cluster cloud basic setting
 	clusterBasicSettingByGKE(cls, cluster, opt)
 	// cluster cloud network setting

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/google/tasks/createCluster.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/google/tasks/createCluster.go
@@ -303,8 +303,10 @@ func generateCreateClusterRequest(info *cloudprovider.CloudDependBasicInfo, // n
 // generateCreateClusterNodePoolInput generate create node pool input
 func generateCreateClusterNodePoolInput(group *proto.NodeGroup, cluster *proto.Cluster) *api.CreateNodePoolRequest {
 	if group.NodeTemplate.MaxPodsPerNode == 0 {
-		group.NodeTemplate.MaxPodsPerNode = 110
+		// 节点池不指定最大 Pods 限制时，使用集群默认值
+		group.NodeTemplate.MaxPodsPerNode = cluster.NetworkSettings.MaxNodePodNum
 	}
+
 	return &api.CreateNodePoolRequest{
 		NodePool: &api.NodePool{
 			// gke nodePool名称中不允许有大写字母

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/google/tasks/deleteCluster.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/google/tasks/deleteCluster.go
@@ -15,6 +15,7 @@ package tasks
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Tencent/bk-bcs/bcs-common/common/blog"
@@ -64,7 +65,7 @@ func DeleteGKEClusterTask(taskID string, stepName string) error {
 
 	if basicInfo.Cluster.SystemID != "" {
 		err = cli.DeleteCluster(context.Background(), basicInfo.Cluster.SystemID)
-		if err != nil {
+		if err != nil && !strings.Contains(err.Error(), "Not found") {
 			blog.Errorf("DeleteGKEClusterTask[%s]: call google DeleteGKECluster failed: %v",
 				taskID, err)
 			retErr := fmt.Errorf("call google DeleteGKECluster failed: %s", err.Error())


### PR DESCRIPTION
1. 修复导入谷歌autopilot类型集群还显示弹性扩缩容选项的问题
2. 修复创建节点池如果不指定MaxPodsConstraint的时候使用集群默认MaxPodsConstraint的值
3. 修复集群在谷歌云上被删除，在bcs平台上没判断是否存在导致一直删除失败