### PR TITLE
feat: 集群外组件部署切换使用低权限token

### DIFF
--- a/bcs-services/bcs-cluster-manager/go.mod
+++ b/bcs-services/bcs-cluster-manager/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/RichardKnop/machinery/v2 v2.0.11
 	github.com/Tencent/bk-bcs/bcs-common v0.0.0-20240725124512-1f33a499f31d
 	github.com/Tencent/bk-bcs/bcs-common/common/encryptv2 v0.0.0-20230908045126-c9d09981a9c5
-	github.com/Tencent/bk-bcs/bcs-services/pkg v0.0.0-20240418123107-72b120390195
+	github.com/Tencent/bk-bcs/bcs-services/pkg v0.0.0-20250726144809-40d47ba97961
 	github.com/apparentlymart/go-cidr v1.1.0
 	github.com/avast/retry-go v2.7.0+incompatible
 	github.com/aws/aws-sdk-go v1.55.5

--- a/bcs-services/bcs-cluster-manager/internal/auth/auth.go
+++ b/bcs-services/bcs-cluster-manager/internal/auth/auth.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/Tencent/bk-bcs/bcs-common/common/blog"
@@ -145,6 +146,13 @@ func CheckUserPerm(ctx context.Context, req server.Request, username string) (bo
 		return false, err
 	}
 
+	if len(resourceID.ClusterID) != 0 && checkClusterClient(username) {
+		if username != resourceID.ClusterID {
+			return false, errors.New("no permission: username must match clusterID")
+		}
+		return true, nil
+	}
+
 	action, ok := ActionPermissions[req.Method()]
 	if !ok {
 		return false, errors.New("operation has not authorized")
@@ -233,4 +241,14 @@ var checkUserBizPerm func(username string, businessID string) (bool, error)
 // SetCheckBizPerm xxx
 func SetCheckBizPerm(f func(username string, businessID string) (bool, error)) {
 	checkUserBizPerm = f
+}
+
+var clusterIdRe = regexp.MustCompile("^BCS-[^-]+-.+$")
+
+// checkClusterUser check clusterId
+func checkClusterClient(username string) bool {
+	if clusterIdRe.MatchString(username) {
+		return true
+	}
+	return false
 }

--- a/bcs-services/bcs-cluster-manager/internal/auth/auth.go
+++ b/bcs-services/bcs-cluster-manager/internal/auth/auth.go
@@ -247,8 +247,5 @@ var clusterIdRe = regexp.MustCompile("^BCS-[^-]+-.+$")
 
 // checkClusterUser check clusterId
 func checkClusterClient(username string) bool {
-	if clusterIdRe.MatchString(username) {
-		return true
-	}
-	return false
+	return clusterIdRe.MatchString(username)
 }

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/component/autoscaler/values.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/component/autoscaler/values.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	cmproto "github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/api/clustermanager"
+	"github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/cloudprovider/utils"
 	cmoptions "github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/options"
 )
 
@@ -167,6 +168,12 @@ type AutoScaler struct {
 
 // GetValues get autoScaler values
 func (as *AutoScaler) GetValues() (string, error) {
+	// build cluster user token
+	token, err := utils.BuildBcsAgentToken(as.AutoScalingOption.ClusterID, false)
+	if err != nil {
+		return "", err
+	}
+
 	if len(as.NodeGroups) == 0 {
 		as.Replicas = 0
 	}
@@ -179,7 +186,7 @@ func (as *AutoScaler) GetValues() (string, error) {
 	values := AutoScalerValues{
 		Namespace:    op.ComponentDeploy.AutoScaler.ReleaseNamespace,
 		APIAddress:   op.ComponentDeploy.BCSAPIGateway,
-		Token:        op.ComponentDeploy.Token,
+		Token:        token,
 		ReplicaCount: as.Replicas,
 		Encryption:   encryptNo,
 		Registry: func() string {

--- a/bcs-services/bcs-cluster-manager/internal/cloudprovider/component/watch/values.go
+++ b/bcs-services/bcs-cluster-manager/internal/cloudprovider/component/watch/values.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Tencent/bk-bcs/bcs-common/common/static"
 	"gopkg.in/yaml.v2"
 
+	cloudproviderUtils "github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/cloudprovider/utils"
 	cmoptions "github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/options"
 	"github.com/Tencent/bk-bcs/bcs-services/bcs-cluster-manager/internal/utils"
 )
@@ -39,6 +40,7 @@ type ValuesTemplate struct {
 	Env struct {
 		ClusterID     string `yaml:"BK_BCS_clusterId"`
 		StorageServer string `yaml:"BK_BCS_customStorage"`
+		StorageToken  string `yaml:"BK_BCS_customStorageToken"`
 		ClientPwd     string `yaml:"BK_BCS_clientKeyPassword"`
 	}
 	Secret struct {
@@ -75,6 +77,11 @@ func (bw *BcsWatch) GetValues() (string, error) {
 		bw.Replicas = defaultReplicas
 	}
 
+	token, err := cloudproviderUtils.BuildBcsAgentToken(bw.ClusterID, false)
+	if err != nil {
+		return "", err
+	}
+
 	// get config info
 	op := cmoptions.GetGlobalCMOptions()
 	var (
@@ -93,10 +100,12 @@ func (bw *BcsWatch) GetValues() (string, error) {
 		Env: struct {
 			ClusterID     string `yaml:"BK_BCS_clusterId"`
 			StorageServer string `yaml:"BK_BCS_customStorage"`
+			StorageToken  string `yaml:"BK_BCS_customStorageToken"`
 			ClientPwd     string `yaml:"BK_BCS_clientKeyPassword"`
 		}{
 			ClusterID:     bw.ClusterID,
 			StorageServer: op.ComponentDeploy.Watch.StorageServer,
+			StorageToken:  token,
 			ClientPwd:     static.ClientCertPwd,
 		},
 		Secret: struct {

--- a/bcs-services/bcs-k8s-watch/app/app.go
+++ b/bcs-services/bcs-k8s-watch/app/app.go
@@ -134,7 +134,7 @@ func RunAsLeader(stopChan <-chan struct{}, config *options.WatchConfig, clusterI
 
 	glog.Info("getting storage service now...")
 	storageService, _, err := bcs.GetStorageService(config.BCS.ZkHosts, bcsTLSConfig, config.BCS.CustomStorageEndpoints,
-		config.BCS.IsExternal)
+		config.BCS.IsExternal, config.BCS.CustomStorageEndpointToken)
 	if err != nil {
 		panic(err)
 	}

--- a/bcs-services/bcs-k8s-watch/app/bcs/cluster.go
+++ b/bcs-services/bcs-k8s-watch/app/bcs/cluster.go
@@ -26,11 +26,11 @@ import (
 
 // GetStorageService returns storage InnerService object for discovery.
 // in container deployment mode, get storage endpoints from configuration directly
-func GetStorageService(zkHosts string, bcsTLSConfig bcsoptions.TLS, customIPStr string, isExternal bool) (*InnerService,
+func GetStorageService(zkHosts string, bcsTLSConfig bcsoptions.TLS, customIPStr string, isExternal bool, token string) (*InnerService,
 	*RegisterDiscover.RegDiscover, error) {
 	customEndpoints := strings.Split(customIPStr, ",")
 	storageService := NewInnerService(types.BCS_MODULE_STORAGE, nil, customEndpoints, isExternal)
-	storageService.update(customEndpoints, bcsTLSConfig)
+	storageService.update(customEndpoints, bcsTLSConfig, token)
 	return storageService, nil, nil
 }
 
@@ -56,7 +56,7 @@ func GetNetService(zkHosts string, bcsTLSConfig bcsoptions.TLS, customIPStr stri
 		customEndpoints = strings.Split(customIPStr, ",")
 	}
 	netService := NewInnerService(types.BCS_MODULE_NETSERVICE, eventChan, customEndpoints, isExternal)
-	go netService.Watch(bcsTLSConfig) // nolint
+	go netService.Watch(bcsTLSConfig, "") // nolint
 
 	return netService, discovery, nil
 }

--- a/bcs-services/bcs-k8s-watch/app/bcs/service.go
+++ b/bcs-services/bcs-k8s-watch/app/bcs/service.go
@@ -44,6 +44,8 @@ type HTTPClientConfig struct {
 
 	// Password is certificate authority file password.
 	Password string
+	// Token is authorization token
+	Token string
 }
 
 // InnerService is bcs inner service for discovery.
@@ -72,7 +74,7 @@ func NewInnerService(serviceName string, eventChan <-chan *RegisterDiscover.Disc
 }
 
 // Watch keeps watching service instance endpoints from ZK.
-func (s *InnerService) Watch(bcsTLSConfig bcsoptions.TLS) error {
+func (s *InnerService) Watch(bcsTLSConfig bcsoptions.TLS, token string) error {
 	glog.Infof("start to watch service[%s] from ZK", s.name)
 
 	if s.eventChan == nil {
@@ -85,7 +87,7 @@ func (s *InnerService) Watch(bcsTLSConfig bcsoptions.TLS) error {
 			glog.Errorf("%s service discover failed, %+v", s.name, data.Err)
 			continue
 		}
-		s.update(data.Server, bcsTLSConfig)
+		s.update(data.Server, bcsTLSConfig, token)
 	}
 
 	return nil
@@ -105,7 +107,7 @@ func (s *InnerService) Servers() []*HTTPClientConfig {
 	return cfgs
 }
 
-func (s *InnerService) update(servers []string, bcsTLSConfig bcsoptions.TLS) {
+func (s *InnerService) update(servers []string, bcsTLSConfig bcsoptions.TLS, token string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -128,6 +130,7 @@ func (s *InnerService) update(servers []string, bcsTLSConfig bcsoptions.TLS) {
 				config := HTTPClientConfig{
 					URL:    address,
 					Scheme: scheme,
+					Token:  token,
 				}
 
 				// support https.
@@ -166,6 +169,7 @@ func (s *InnerService) update(servers []string, bcsTLSConfig bcsoptions.TLS) {
 				config := HTTPClientConfig{
 					URL:    address,
 					Scheme: serverInfo.Scheme,
+					Token:  token,
 				}
 
 				// support https.

--- a/bcs-services/bcs-k8s-watch/app/options/options.go
+++ b/bcs-services/bcs-k8s-watch/app/options/options.go
@@ -61,6 +61,8 @@ type BCSConfig struct {
 
 	// whether the k8s cluster and bcs-k8s-watch is in external network
 	IsExternal bool `json:"is-external"`
+	// authorization token
+	CustomStorageEndpointToken string `json:"custom-storage-endpoints-token"`
 
 	// WriterQueueLen show writer module chan queue length for data distribute, default 10240
 	WriterQueueLen int64 `json:"writerQueueLen"`

--- a/bcs-services/bcs-k8s-watch/app/output/http/client.go
+++ b/bcs-services/bcs-k8s-watch/app/output/http/client.go
@@ -254,6 +254,7 @@ func (client *StorageClient) GET() (storageResp StorageResponse, err error) {
 	resp, _, errs := request.
 		Timeout(StorageRequestTimeoutSeconds*time.Second).
 		Get(url).
+		Set("Authorization", fmt.Sprintf("Bearer %s", client.HTTPClientConfig.Token)).
 		Retry(2, 2*time.Second, http.StatusBadRequest, http.StatusInternalServerError).
 		EndStruct(&storageResp)
 
@@ -291,6 +292,7 @@ func (client *StorageClient) DELETE() (storageResp StorageResponse, err error) {
 	resp, _, errs := request.
 		Timeout(StorageRequestTimeoutSeconds*time.Second).
 		Delete(url).
+		Set("Authorization", fmt.Sprintf("Bearer %s", client.HTTPClientConfig.Token)).
 		Retry(3, 1*time.Second, http.StatusBadRequest, http.StatusInternalServerError).
 		EndStruct(&storageResp)
 
@@ -334,6 +336,7 @@ func (client *StorageClient) PUT(data interface{}) (storageResp StorageResponse,
 		Timeout(StorageRequestTimeoutSeconds*time.Second).
 		Put(url).
 		Send(body).
+		Set("Authorization", fmt.Sprintf("Bearer %s", client.HTTPClientConfig.Token)).
 		Retry(3, 1*time.Second, http.StatusBadRequest, http.StatusInternalServerError).
 		EndStruct(&storageResp)
 

--- a/install/conf/bcs-services/bcs-k8s-watch/bcs-k8s-watch.json.template
+++ b/install/conf/bcs-services/bcs-k8s-watch/bcs-k8s-watch.json.template
@@ -20,6 +20,7 @@
         "is-external": ${kubeWatchExternal},
         "netservice-zookeepers": "${customNetServiceZK}",
         "custom-storage-endpoints": "${customStorage}",
+        "custom-storage-endpoints-token": "${customStorageToken}",
         "custom-netservice-endpoints": "${customNetService}",
         "writerQueueLen": ${writerQueueLen},
         "podQueueNum": ${podQueueNum}


### PR DESCRIPTION
bcs-k8s-watch和bcs-auto-scaler在集群纳管安装时，默认使用的是admin token。需替换成低权限的集群token，并且在cluster manager的鉴权中对这类集群token做特殊处理，如果是集群token（username是clusterID格式的）并且请求自身集群的资源则放行。