### PR TITLE
fix: 修复导入集群分发任务是rabbitmq异常导致集群一直处于初始化状态

### DIFF
--- a/bcs-ui/frontend/src/views/cluster-manage/cluster/table-cell-action.vue
+++ b/bcs-ui/frontend/src/views/cluster-manage/cluster/table-cell-action.vue
@@ -9,7 +9,7 @@
       </bk-button>
     </template>
     <!-- 失败状态 -->
-    <template v-else-if="['CREATE-FAILURE', 'DELETE-FAILURE'].includes(row.status)">
+    <template v-else-if="['CREATE-FAILURE', 'DELETE-FAILURE', 'IMPORT-FAILURE'].includes(row.status)">
       <bk-button
         class="mr-[10px]"
         text


### PR DESCRIPTION
修复：

- 导入集群: 在任务分发（Dispatch）失败时，显式将集群状态置为 IMPORT-FAILURE，任务状态置为 Failure，防止集群卡在“初始化中”。
- 任务重试: 若重试操作分发失败，将任务状态回滚至原状态，避免错误地停留在 Running。
- 前端适配: 支持为 IMPORT-FAILURE 状态的集群显示操作按钮（如重试/删除）。
