### PR TITLE
fix: apisix bcs-dynamic-route 插件不支持带路径后缀的集群地址

### DIFF
--- a/bcs-services/bcs-bk-apisix-gateway/plugins/bcs-dynamic-route.lua
+++ b/bcs-services/bcs-bk-apisix-gateway/plugins/bcs-dynamic-route.lua
@@ -374,23 +374,36 @@ local function periodly_sync_cluster_credentials_in_master()
         end
         local upstream_nodes = {}
         local addresses = stringx.split(cluster_credential["serverAddress"], ",")
+        local prefix = ""
         for i, address in ipairs(addresses) do
             local splited = stringx.split(address, "://")
             local scheme = "https"
-            if #splited ~= 2 then
-                upstream_nodes[i] = {
-                    host = address,
-                    weight = 100,
-                }
-            else
+            local host_and_path = address
+            if #splited == 2 then
                 scheme = splited[1]
-                upstream_nodes[i] = {
-                    host = splited[2],
-                    weight = 100,
-                }
+                host_and_path = splited[2]
             end
+
+            -- Split host:port and path prefix
+            local host_port, path = host_and_path:match("^([^/]+)(/.*)$")
+            if not host_port then
+                host_port = host_and_path
+                path = ""
+            end
+
+            -- Strip trailing slash
+            if path:sub(-1) == "/" then
+                path = path:sub(1, -2)
+            end
+            if prefix == "" then
+                prefix = path
+            end
+
+            upstream_nodes[i] = {
+                weight = 100,
+            }
             -- port is required, 443 as default port
-            local host, port = core.utils.parse_addr(upstream_nodes[i].host)
+            local host, port = core.utils.parse_addr(host_port)
             upstream_nodes[i].host = host
             if not port then
                 if scheme == "http" then
@@ -404,6 +417,7 @@ local function periodly_sync_cluster_credentials_in_master()
                 upstream_nodes[i].port = port
             end
         end
+        cluster_info["prefix"] = prefix
 
         -- 定义一个通用的节点健康检查函数
         local function check_nodes_health(upstream_nodes, check_func, cluster_credential)
@@ -528,7 +542,8 @@ end
 
 -- proxy to apiserver directly
 local function traffic_to_cluster_apiserver(conf, ctx, cluster_credential, upstream_uri)
-    ctx.var.upstream_uri = "/" .. upstream_uri
+    local prefix = cluster_credential["prefix"] or ""
+    ctx.var.upstream_uri = prefix .. "/" .. upstream_uri
     if cluster_credential["user_token"] then
         core.request.set_header(ctx, "Authorization", "Bearer " .. cluster_credential["user_token"])
     end

--- a/bcs-services/bcs-gateway-discovery/plugins/apisix/bcs-dynamic-route.lua
+++ b/bcs-services/bcs-gateway-discovery/plugins/apisix/bcs-dynamic-route.lua
@@ -353,23 +353,36 @@ local function periodly_sync_cluster_credentials_in_master()
         end
         local upstream_nodes = {}
         local addresses = stringx.split(cluster_credential["serverAddress"], ",")
+        local prefix = ""
         for i, address in ipairs(addresses) do
             local splited = stringx.split(address, "://")
             local scheme = "https"
-            if #splited ~= 2 then
-                upstream_nodes[i] = {
-                    host = address,
-                    weight = 100,
-                }
-            else
+            local host_and_path = address
+            if #splited == 2 then
                 scheme = splited[1]
-                upstream_nodes[i] = {
-                    host = splited[2],
-                    weight = 100,
-                }
+                host_and_path = splited[2]
             end
+
+            -- Split host:port and path prefix
+            local host_port, path = host_and_path:match("^([^/]+)(/.*)$")
+            if not host_port then
+                host_port = host_and_path
+                path = ""
+            end
+
+            -- Strip trailing slash
+            if path:sub(-1) == "/" then
+                path = path:sub(1, -2)
+            end
+            if prefix == "" then
+                prefix = path
+            end
+
+            upstream_nodes[i] = {
+                weight = 100,
+            }
             -- port is required, 443 as default port
-            local host, port = core.utils.parse_addr(upstream_nodes[i].host)
+            local host, port = core.utils.parse_addr(host_port)
             upstream_nodes[i].host = host
             if not port then
                 if scheme == "http" then
@@ -383,6 +396,7 @@ local function periodly_sync_cluster_credentials_in_master()
                 upstream_nodes[i].port = port
             end
         end
+        cluster_info["prefix"] = prefix
 
         -- 定义一个通用的节点健康检查函数
         local function check_nodes_health(upstream_nodes, check_func, cluster_credential)
@@ -506,7 +520,8 @@ end
 
 -- proxy to apiserver directly
 local function traffic_to_cluster_apiserver(conf, ctx, cluster_credential, upstream_uri)
-    ctx.var.upstream_uri = "/" .. upstream_uri
+    local prefix = cluster_credential["prefix"] or ""
+    ctx.var.upstream_uri = prefix .. "/" .. upstream_uri
     if cluster_credential["user_token"] then
         core.request.set_header(ctx, "Authorization", "Bearer " .. cluster_credential["user_token"])
     end


### PR DESCRIPTION
在此之前，插件仅从集群凭证的 serverAddress 中解析 host 和 port。如果地址中包含子路径（Path），解析逻辑会忽略该路径或导致解析错误，且在转发请求给集群 APIServer 进行 URI 重写时，未包含该前缀，导致请求返回 404 Not Found。

解决方案 (Solution)
- 增强地址解析：更新了地址拆分逻辑，支持同时提取 host:port 和路径前缀 prefix。
- 完善凭证缓存：在动态路由缓存中增加了 prefix 字段，用于持久化存储提取到的路径前缀。
- 优化 URI 重写逻辑：修改了 traffic_to_cluster_apiserver 函数，在代理转发前将存储的 prefix 自动拼接到 upstream_uri 中。
- 全量修复：同步修复了 BCS 中两处受影响的插件位置：
  - bcs-services/bcs-gateway-discovery/plugins/apisix/bcs-dynamic-route.lua
  - bcs-services/bcs-bk-apisix-gateway/plugins/bcs-dynamic-route.lua