### PR TITLE
fix: 修复集群切换为共享集群时缓存未刷新导致的操作报错

### DIFF
--- a/bcs-services/bcs-project-manager/internal/actions/namespace/factory.go
+++ b/bcs-services/bcs-project-manager/internal/actions/namespace/factory.go
@@ -58,6 +58,13 @@ func (f *NamespaceFactory) Action(ctx context.Context, clusterID, projectIDOrCod
 		logging.Error("get project from db failed, err: %s", err.Error())
 		return nil, err
 	}
+	// 若缓存信息校验失败，则绕过缓存重新拉取一次，防止集群状态刚切换时产生误判
+	if cluster.GetProjectID() != project.ProjectID && !cluster.GetIsShared() {
+		if freshCluster, err := clustermanager.GetCluster(ctx, clusterID, false); err == nil && freshCluster != nil {
+			cluster = freshCluster
+		}
+	}
+
 	if cluster.GetProjectID() != project.ProjectID {
 		if cluster.GetIsShared() {
 			return shared.NewSharedNamespaceAction(f.model), nil

--- a/bcs-services/bcs-project-manager/internal/component/clustermanager/client.go
+++ b/bcs-services/bcs-project-manager/internal/component/clustermanager/client.go
@@ -66,7 +66,7 @@ func GetCluster(ctx context.Context, clusterID string, isCache bool) (*clusterma
 		logging.Error("get cluster from cluster manager failed, msg: %s", resp.GetMessage())
 		return nil, errors.New(resp.GetMessage())
 	}
-	_ = c.Add(fmt.Sprintf(CacheKeyClusterPrefix, clusterID), resp.GetData(), 5*time.Minute)
+	c.Set(fmt.Sprintf(CacheKeyClusterPrefix, clusterID), resp.GetData(), 5*time.Minute)
 	return resp.GetData(), nil
 }
 


### PR DESCRIPTION
**问题背景**
在 `project-manager` 中，由于底层对集群信息存在本地缓存，当集群属性发生变更（例如临时切换为共享集群，或被重新分配到当前项目）时，由于缓存未及时刷新，会导致进行命名空间操作等鉴权时被直接拦截，报错 `project or cluster not valid`。
**解决方案**

在 `NamespaceFactory.Action` 校验失败时增加兜底逻辑：
若发现缓存中的集群既不归属当前项目，也不是共享集群，则利用 `GetCluster` 接口绕过本地缓存（`isCache=false`）强拉一次服务端最新数据进行二次校验，避免因为缓存延迟导致误判。

