### PR TITLE
feat: 命名空间配额支持调整 Request 和 Limit

### DIFF
--- a/bcs-services/bcs-project-manager/etc/bcs-project-manager.yaml
+++ b/bcs-services/bcs-project-manager/etc/bcs-project-manager.yaml
@@ -92,9 +92,10 @@ bcsGateway:
 taskConfig:
   address: ""
   exchange: ""
-  workerCnt: ""
+  workerCnt: 0
 sharedClusterConfig:
   annoKeyProjCode: ""
+  allowAdjustQuota: false
 systemConfig:
   systemNameSpaces:
   - "bcs"

--- a/bcs-services/bcs-project-manager/internal/actions/namespace/shared/create.go
+++ b/bcs-services/bcs-project-manager/internal/actions/namespace/shared/create.go
@@ -142,5 +142,10 @@ func (a *SharedNamespaceAction) validateCreate(ctx context.Context, req *proto.C
 	if err := quotautils.ValidateResourceQuota(req.Quota); err != nil {
 		return err
 	}
+	if !config.GlobalConf.SharedClusterConfig.AllowAdjustQuota {
+		if err := quotautils.ValidateQuotaEquality(req.Quota); err != nil {
+			return err
+		}
+	}
 	return nil
 }

--- a/bcs-services/bcs-project-manager/internal/actions/namespace/shared/update.go
+++ b/bcs-services/bcs-project-manager/internal/actions/namespace/shared/update.go
@@ -34,13 +34,18 @@ import (
 // UpdateNamespace implement for UpdateNamespace interface
 func (a *SharedNamespaceAction) UpdateNamespace(ctx context.Context,
 	req *proto.UpdateNamespaceRequest, resp *proto.UpdateNamespaceResponse) error {
+	if err := quotautils.ValidateResourceQuota(req.Quota); err != nil {
+		return err
+	}
+	if !config.GlobalConf.SharedClusterConfig.AllowAdjustQuota {
+		if err := quotautils.ValidateQuotaEquality(req.Quota); err != nil {
+			return err
+		}
+	}
 	// if itsm is not enable, update namespace directly
 	if !config.GlobalConf.ITSM.Enable {
 		ia := independent.NewIndependentNamespaceAction(a.model)
 		return ia.UpdateNamespace(ctx, req, resp)
-	}
-	if err := quotautils.ValidateResourceQuota(req.Quota); err != nil {
-		return err
 	}
 	var username string
 	if authUser, err := middleware.GetUserFromContext(ctx); err == nil {

--- a/bcs-services/bcs-project-manager/internal/config/config.go
+++ b/bcs-services/bcs-project-manager/internal/config/config.go
@@ -183,7 +183,8 @@ type TaskConfig struct {
 
 // SharedClusterConfig 共享集群相关配置
 type SharedClusterConfig struct {
-	AnnoKeyProjCode string `yaml:"annoKeyProjCode"`
+	AnnoKeyProjCode  string `yaml:"annoKeyProjCode"`
+	AllowAdjustQuota bool   `yaml:"allowAdjustQuota"`
 }
 
 // SystemCommonConfig 系统公共配置

--- a/bcs-services/bcs-project-manager/internal/util/quota/quota.go
+++ b/bcs-services/bcs-project-manager/internal/util/quota/quota.go
@@ -183,3 +183,34 @@ func load(quota *corev1.ResourceQuota, cpuLimits, cpuRequests, memoryLimits, mem
 	}
 	return nil
 }
+
+// ValidateQuotaEquality checks if CPU/Memory request and limit are equal.
+func ValidateQuotaEquality(quota *proto.ResourceQuota) error {
+	if quota == nil {
+		return nil
+	}
+	cpuLimit, err := resource.ParseQuantity(quota.CpuLimits)
+	if err != nil {
+		return errorx.NewParamErr("invalid cpu limits")
+	}
+	cpuRequest, err := resource.ParseQuantity(quota.CpuRequests)
+	if err != nil {
+		return errorx.NewParamErr("invalid cpu requests")
+	}
+	if cpuLimit.Cmp(cpuRequest) != 0 {
+		return errorx.NewReadableErr(errorx.ParamErr, "cpu limits and requests must be consistent under shared cluster")
+	}
+
+	memLimit, err := resource.ParseQuantity(quota.MemoryLimits)
+	if err != nil {
+		return errorx.NewParamErr("invalid memory limits")
+	}
+	memRequest, err := resource.ParseQuantity(quota.MemoryRequests)
+	if err != nil {
+		return errorx.NewParamErr("invalid memory requests")
+	}
+	if memLimit.Cmp(memRequest) != 0 {
+		return errorx.NewReadableErr(errorx.ParamErr, "memory limits and requests must be consistent under shared cluster")
+	}
+	return nil
+}

--- a/bcs-services/bcs-project-manager/internal/util/quota/quota_test.go
+++ b/bcs-services/bcs-project-manager/internal/util/quota/quota_test.go
@@ -16,7 +16,10 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/api/resource"
+
+	proto "github.com/Tencent/bk-bcs/bcs-services/bcs-project-manager/proto/bcsproject"
 )
 
 func TestQuota(t *testing.T) {
@@ -31,4 +34,42 @@ func TestQuota(t *testing.T) {
 		t.Fatal(err)
 	}
 	fmt.Println(q2.AsApproximateFloat64())
+}
+
+func TestValidateQuotaEquality(t *testing.T) {
+	// Case 1: Nil quota
+	err := ValidateQuotaEquality(nil)
+	assert.Nil(t, err)
+
+	// Case 2: Equal CPU and Memory
+	qEqual := &proto.ResourceQuota{
+		CpuLimits:      "2",
+		CpuRequests:    "2000m",
+		MemoryLimits:   "4Gi",
+		MemoryRequests: "4096Mi",
+	}
+	err = ValidateQuotaEquality(qEqual)
+	assert.Nil(t, err)
+
+	// Case 3: Unequal CPU
+	qUnequalCPU := &proto.ResourceQuota{
+		CpuLimits:      "2",
+		CpuRequests:    "1000m",
+		MemoryLimits:   "4Gi",
+		MemoryRequests: "4Gi",
+	}
+	err = ValidateQuotaEquality(qUnequalCPU)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "cpu limits and requests must be consistent under shared cluster")
+
+	// Case 4: Unequal Memory
+	qUnequalMem := &proto.ResourceQuota{
+		CpuLimits:      "2",
+		CpuRequests:    "2",
+		MemoryLimits:   "4Gi",
+		MemoryRequests: "2Gi",
+	}
+	err = ValidateQuotaEquality(qUnequalMem)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "memory limits and requests must be consistent under shared cluster")
 }

--- a/bcs-ui/frontend/src/i18n/en-US.yaml
+++ b/bcs-ui/frontend/src/i18n/en-US.yaml
@@ -2954,6 +2954,7 @@ dashboard:
       setMinMaxMemCpu: >-
         Please set CPU and MEM quotas, and the minimum value must be greater
         than 0.
+      setValidQuota: Please set valid CPU and Memory quotas (Limit >= Request >= 0 / 1 for shared cluster)
     status:
       waitingApproval: Pending
       createNamespace: Create naming space

--- a/bcs-ui/frontend/src/i18n/zh-CN.yaml
+++ b/bcs-ui/frontend/src/i18n/zh-CN.yaml
@@ -2371,6 +2371,7 @@ dashboard:
       name: 命名空间名称只能包含小写字母、数字以及连字符(-)，连字符（-）后面必须接英文或者数字
       sharedClusterNs: '命名规则：{prefix}自定义名称'
       setMinMaxMemCpu: 请设置MEN、CPU配额，且两者最小值不小于0
+      setValidQuota: 请设置合法的 CPU、内存配额，且 Limit 需大于等于 Request（共享集群最小值不小于1）
     status:
       waitingApproval: 待审批
       createNamespace: 创建命名空间

--- a/bcs-ui/frontend/src/views/cluster-manage/namespace/create.vue
+++ b/bcs-ui/frontend/src/views/cluster-manage/namespace/create.vue
@@ -101,30 +101,60 @@
             } : ''"
             error-display-type="normal"
             property="quota">
-            <div class="flex">
-              <div class="flex mr-[20px]">
-                <span class="mr-[15px] text-[14px]">CPU</span>
-                <bcs-input
-                  v-model="formData.quota.cpuRequests"
-                  class="w-[250px]"
-                  type="number"
-                  :min="1"
-                  :max="512000"
-                  :precision="0">
-                  <div class="group-text" slot="append">{{ $t('units.suffix.cores') }}</div>
-                </bcs-input>
+            <div>
+              <div class="flex items-center mb-[15px]">
+                <span class="mr-[15px] text-[14px] w-[50px]">CPU</span>
+                <div class="flex items-center mr-[20px]">
+                  <span class="mr-[10px] text-[12px] text-[#979ba5]">Request</span>
+                  <bcs-input
+                    v-model="formData.quota.cpuRequests"
+                    class="w-[180px]"
+                    type="number"
+                    :min="isSharedCluster ? 1 : 0"
+                    :max="512000"
+                    :precision="0">
+                    <div class="group-text" slot="append">{{ $t('units.suffix.cores') }}</div>
+                  </bcs-input>
+                </div>
+                <div class="flex items-center">
+                  <span class="mr-[10px] text-[12px] text-[#979ba5]">Limit</span>
+                  <bcs-input
+                    v-model="formData.quota.cpuLimits"
+                    class="w-[180px]"
+                    type="number"
+                    :min="isSharedCluster ? 1 : 0"
+                    :max="512000"
+                    :precision="0">
+                    <div class="group-text" slot="append">{{ $t('units.suffix.cores') }}</div>
+                  </bcs-input>
+                </div>
               </div>
-              <div class="flex">
-                <span class="mr-[15px] text-[14px]">MEM</span>
-                <bcs-input
-                  v-model="formData.quota.memoryRequests"
-                  class="w-[250px]"
-                  type="number"
-                  :min="1"
-                  :max="1024000"
-                  :precision="0">
-                  <div class="group-text" slot="append">GiB</div>
-                </bcs-input>
+              <div class="flex items-center">
+                <span class="mr-[15px] text-[14px] w-[50px]">MEM</span>
+                <div class="flex items-center mr-[20px]">
+                  <span class="mr-[10px] text-[12px] text-[#979ba5]">Request</span>
+                  <bcs-input
+                    v-model="formData.quota.memoryRequests"
+                    class="w-[180px]"
+                    type="number"
+                    :min="isSharedCluster ? 1 : 0"
+                    :max="1024000"
+                    :precision="0">
+                    <div class="group-text" slot="append">GiB</div>
+                  </bcs-input>
+                </div>
+                <div class="flex items-center">
+                  <span class="mr-[10px] text-[#979ba5] text-[12px]">Limit</span>
+                  <bcs-input
+                    v-model="formData.quota.memoryLimits"
+                    class="w-[180px]"
+                    type="number"
+                    :min="isSharedCluster ? 1 : 0"
+                    :max="1024000"
+                    :precision="0">
+                    <div class="group-text" slot="append">GiB</div>
+                  </bcs-input>
+                </div>
               </div>
             </div>
           </bk-form-item>
@@ -206,15 +236,28 @@ export default defineComponent({
           trigger: 'blur',
         },
       ],
-      quota: isSharedCluster.value ? [
+      quota: [
         {
           validator() {
-            return Number(formData.value.quota.cpuRequests) >= 1 && Number(formData.value.quota.memoryRequests) >= 1;
+            const { cpuRequests, cpuLimits, memoryRequests, memoryLimits } = formData.value.quota;
+            const cpuReq = Number(cpuRequests);
+            const cpuLim = Number(cpuLimits);
+            const memReq = Number(memoryRequests);
+            const memLim = Number(memoryLimits);
+            if (isSharedCluster.value) {
+              return cpuReq >= 1 && cpuLim >= cpuReq && memReq >= 1 && memLim >= memReq;
+            }
+            // 非共享集群允许均为空
+            if (!cpuRequests && !cpuLimits && !memoryRequests && !memoryLimits) {
+              return true;
+            }
+            // 若填了其中任何一个，必须全部填且满足关系
+            return !!(cpuRequests && cpuLimits && memoryRequests && memoryLimits && cpuReq >= 0 && cpuLim >= cpuReq && memReq >= 0 && memLim >= memReq);
           },
-          message: $i18n.t('dashboard.ns.validate.setMinMaxMemCpu'),
+          message: $i18n.t('dashboard.ns.validate.setValidQuota'),
           trigger: 'blur',
         },
-      ] : [],
+      ],
       labels: [
         {
           validator() {
@@ -288,12 +331,13 @@ export default defineComponent({
         }
         isLoading.value = true;
         let quota: Record<string, string> | null = null;
-        if (formData.value.quota.cpuRequests || formData.value.quota.memoryRequests) {
+        const { cpuRequests, cpuLimits, memoryRequests, memoryLimits } = formData.value.quota;
+        if (cpuRequests || cpuLimits || memoryRequests || memoryLimits) {
           quota = {
-            cpuLimits: String(formData.value.quota.cpuRequests),
-            cpuRequests: String(formData.value.quota.cpuRequests),
-            memoryLimits: `${formData.value.quota.memoryRequests}Gi`,
-            memoryRequests: `${formData.value.quota.memoryRequests}Gi`,
+            cpuLimits: String(cpuLimits),
+            cpuRequests: String(cpuRequests),
+            memoryLimits: `${memoryLimits}Gi`,
+            memoryRequests: `${memoryRequests}Gi`,
           };
         }
         const result = await handleCreatedNamespace({

--- a/bcs-ui/frontend/src/views/cluster-manage/namespace/namespace.vue
+++ b/bcs-ui/frontend/src/views/cluster-manage/namespace/namespace.vue
@@ -327,22 +327,50 @@
           label="CPU"
           property="quota"
           error-display-type="normal">
-          <div class="flex mr-[20px]">
+          <div class="flex items-center">
+            <span class="mr-[10px] text-[12px] text-[#979ba5]">Request</span>
             <bcs-input
               v-model="setQuotaConf.quota.cpuRequests"
-              class="w-[200px]"
+              class="w-[150px] mr-[20px]"
               type="number"
-              :min="1"
+              :min="isSharedCluster ? 1 : 0"
               :max="512000"
               :precision="0">
               <div class="group-text" slot="append">{{ $t('units.suffix.cores') }}</div>
             </bcs-input>
-            <span class="mx-[10px]">Mem</span>
+            <span class="mr-[10px] text-[12px] text-[#979ba5]">Limit</span>
+            <bcs-input
+              v-model="setQuotaConf.quota.cpuLimits"
+              class="w-[150px]"
+              type="number"
+              :min="isSharedCluster ? 1 : 0"
+              :max="512000"
+              :precision="0">
+              <div class="group-text" slot="append">{{ $t('units.suffix.cores') }}</div>
+            </bcs-input>
+          </div>
+        </bk-form-item>
+        <bk-form-item
+          v-if="showQuota"
+          label="Memory"
+          error-display-type="normal">
+          <div class="flex items-center">
+            <span class="mr-[10px] text-[12px] text-[#979ba5]">Request</span>
             <bcs-input
               v-model="setQuotaConf.quota.memoryRequests"
-              class="w-[200px]"
+              class="w-[150px] mr-[20px]"
               type="number"
-              :min="1"
+              :min="isSharedCluster ? 1 : 0"
+              :max="1024000"
+              :precision="0">
+              <div class="group-text" slot="append">GiB</div>
+            </bcs-input>
+            <span class="mr-[10px] text-[12px] text-[#979ba5]">Limit</span>
+            <bcs-input
+              v-model="setQuotaConf.quota.memoryLimits"
+              class="w-[150px]"
+              type="number"
+              :min="isSharedCluster ? 1 : 0"
               :max="1024000"
               :precision="0">
               <div class="group-text" slot="append">GiB</div>
@@ -498,8 +526,14 @@ export default defineComponent({
       if (!setQuotaConf.value.quota.cpuRequests) {
         setQuotaConf.value.quota.cpuRequests = '1';
       }
+      if (!setQuotaConf.value.quota.cpuLimits) {
+        setQuotaConf.value.quota.cpuLimits = '1';
+      }
       if (!setQuotaConf.value.quota.memoryRequests) {
         setQuotaConf.value.quota.memoryRequests = '1';
+      }
+      if (!setQuotaConf.value.quota.memoryLimits) {
+        setQuotaConf.value.quota.memoryLimits = '1';
       }
       showQuota.value = !showQuota.value;
     };
@@ -507,10 +541,20 @@ export default defineComponent({
     const quotaRules = [
       {
         validator() {
-          return setQuotaConf.value.quota.cpuRequests && setQuotaConf.value.quota.memoryRequests
-              && setQuotaConf.value.quota.cpuRequests !== 'NaN' && setQuotaConf.value.quota.memoryRequests !== 'NaN';
+          const { cpuRequests, cpuLimits, memoryRequests, memoryLimits } = setQuotaConf.value.quota;
+          const cpuReq = Number(cpuRequests);
+          const cpuLim = Number(cpuLimits);
+          const memReq = Number(memoryRequests);
+          const memLim = Number(memoryLimits);
+          if (!cpuRequests || !cpuLimits || !memoryRequests || !memoryLimits) {
+            return false;
+          }
+          if (isSharedCluster.value) {
+            return cpuReq >= 1 && cpuLim >= cpuReq && memReq >= 1 && memLim >= memReq;
+          }
+          return cpuReq >= 0 && cpuLim >= cpuReq && memReq >= 0 && memLim >= memReq;
         },
-        message: $i18n.t('dashboard.ns.validate.setMinMaxMemCpu'),
+        message: $i18n.t('dashboard.ns.validate.setValidQuota'),
         trigger: 'blur',
       },
     ];
@@ -668,10 +712,10 @@ export default defineComponent({
       setQuotaConf.value.annotations = annotations;
       if (quota) {
         setQuotaConf.value.quota = {
-          cpuLimits: quota.cpuLimits || '',
-          cpuRequests: unitConvert(quota.cpuRequests, '', 'cpu'),
-          memoryLimits: quota.memoryLimits || '',
-          memoryRequests: unitConvert(quota.memoryRequests, 'Gi', 'mem'),
+          cpuLimits: unitConvert(quota.cpuLimits || '', '', 'cpu'),
+          cpuRequests: unitConvert(quota.cpuRequests || '', '', 'cpu'),
+          memoryLimits: unitConvert(quota.memoryLimits || '', 'Gi', 'mem'),
+          memoryRequests: unitConvert(quota.memoryRequests || '', 'Gi', 'mem'),
         };
       }
     };
@@ -687,9 +731,9 @@ export default defineComponent({
           labels,
           annotations,
           quota: showQuota.value ? {
-            cpuLimits: String(quota.cpuRequests),
+            cpuLimits: String(quota.cpuLimits),
             cpuRequests: String(quota.cpuRequests),
-            memoryLimits: `${quota.memoryRequests}Gi`,
+            memoryLimits: `${quota.memoryLimits}Gi`,
             memoryRequests: `${quota.memoryRequests}Gi`,
           } : null,
         });


### PR DESCRIPTION
同 #3845 ，合入master分支：

### 背景 (Background)

目前前端页面在创建和修改命名空间时，仅支持填写一个统一的 CPU/Memory 配额，页面上默认 limit 和 request 是相等的，这主要是为了防止超卖。

在此之前，后端 project-manager 接口层并未对此限制进行严格的强校验。经讨论，我们在 project-manager 中新增一个配置开关，来控制共享集群是否允许 limit 和 request 不一致：

- 共享集群（当配置为 false，即默认值）：强校验 limit 与 request 必须保持一致，防止超卖。
- 共享集群（当配置为 true）：允许 limit 与 request 不一致。
- 独立集群：保持原样，不做限制。

### 主要改动 (Key Changes)

- 前端 (bcs-ui)：
    - 拆分了命名空间配额设置中 CPU/Memory 的 Limit 和 Request 的页面输入项。
- 后端 (bcs-project-manager)：
    - 新增 sharedClusterConfig.allowAdjustQuota 配置开关。
    - 对共享集群命名空间配额操作，添加了当 allowAdjustQuota = false 时强制限制 Request == Limit 的校验逻辑（ValidateQuotaEquality）。