### PR TITLE
fix: bcs-storage支持单节点副本集查询自动降级到主节点

### DIFF
--- a/bcs-services/bcs-storage/storage/actions/v1http/events/utils.go
+++ b/bcs-services/bcs-storage/storage/actions/v1http/events/utils.go
@@ -162,8 +162,8 @@ func listEvent(req *restful.Request) ([]operator.M, int64, error) {
 
 	condition := getCondition(req)
 
-	// set read preference, read from secondary node
-	secondary := readpref.Secondary()
+	// set read preference, read from secondary node preferred
+	secondary := readpref.SecondaryPreferred()
 	dbOpts := mopt.Database().SetReadPreference(secondary)
 
 	// option
@@ -307,8 +307,8 @@ func postEvent(req *restful.Request) ([]operator.M, int64, error) {
 
 	condition := getJsonCondition(eventParams)
 
-	// set read preference, read from secondary node
-	secondary := readpref.Secondary()
+	// set read preference, read from secondary node preferred
+	secondary := readpref.SecondaryPreferred()
 	dbOpts := mopt.Database().SetReadPreference(secondary)
 
 	// option


### PR DESCRIPTION
### 变更说明
将 `bcs-storage` 事件查询中的 MongoDB 读取偏好（Read Preference）由 `Secondary()` 修改为 `SecondaryPreferred()`。
### 变更原因
解决单节点 MongoDB 副本集下的事件查询失败问题：
在单节点副本集部署下（常见于本地轻量化开发/测试环境），由于没有从节点（Secondary），原有的 `Secondary()` 强认证配置会导致查询因找不到可用节点而超时或报错。
修改为 `SecondaryPreferred()` 后：
- 在多节点副本集下：依然优先从从节点读取；
- 在单节点副本集下：找不到从节点时会自动降级到主节点（Primary）进行读取，保证了单节点环境下的查询可用性。