### PR TITLE
fix: (bcs-ui)修复 AWS 导入页面创建云凭证跳转链接错误导致的 404 问题

### DIFF
--- a/bcs-ui/frontend/src/views/cluster-manage/add/import/amazon-cloud.vue
+++ b/bcs-ui/frontend/src/views/cluster-manage/add/import/amazon-cloud.vue
@@ -219,7 +219,7 @@ const handleGetAccountsList = async () => {
   accountLoading.value = false;
 };
 const CloudTokenLink = computed(() => {
-  const { href } = $router.resolve({ name: cloudId });
+  const { href } = $router.resolve({ name: 'amazonCloud' });
   return href;
 });
 // 根据云凭证获取区域列表


### PR DESCRIPTION
### 变更内容
修复了导入集群时，AWS（亚马逊云）导入页面中“新建云凭证”按钮的跳转链接解析错误。

### 变更原因
在 `amazon-cloud.vue` 中，解析路由链接时使用了变量 `cloudId`（值为 `'awsCloud'`），但路由配置中 AWS 凭证页面的实际路由名称为 `'amazonCloud'`。这导致无法正确解析路由地址，点击按钮跳转时会触发 404。

### 验证指引
1. 进入“添加集群 -> 导入集群”页面，选择 AWS（亚马逊云）。
2. 在云凭证选择下拉栏中，点击底部的“新建云凭证”按钮。
3. 验证跳转的新页面是否正确打开云凭证管理页（路径应为 `/project-info/amazon-cloud`），且无 404 错误。
